### PR TITLE
UOE-3512: Fix audienceNetwork interpret wrong AdSizes

### DIFF
--- a/modules/audienceNetworkBidAdapter.js
+++ b/modules/audienceNetworkBidAdapter.js
@@ -36,6 +36,13 @@ const flattenSize = size =>
   (Array.isArray(size) && size.length === 2) ? `${size[0]}x${size[1]}` : size;
 
 /**
+ * Expands a 'WxH' string as a 2-element [W, H] array
+ * @param {String} size
+ * @returns {Array}
+ */
+const expandSize = size => size.split('x').map(Number);
+
+/**
  * Is this a valid slot size?
  * @param {String} size
  * @returns {Boolean}
@@ -85,6 +92,12 @@ ${nativeContainer}</div></body></html>`;
 };
 
 /**
+ * Get the current window location URL correctly encoded for use in a URL query string.
+ * @returns {String} URI-encoded URL
+ */
+const getTopWindowUrlEncoded = () => encodeURIComponent(getTopWindowUrl());
+
+/**
  * Convert each bid request to a single URL to fetch those bids.
  * @param {Array} bids - list of bids
  * @param {String} bids[].placementCode - Prebid placement identifier
@@ -118,7 +131,7 @@ const buildRequests = bids => {
 
   // Build URL
   const testmode = isTestmode();
-  const pageurl = getTopWindowUrl();
+  const pageurl = getTopWindowUrlEncoded();
   const search = {
     placementids,
     adformats,
@@ -163,7 +176,7 @@ const interpretResponse = ({ body }, { adformats, requestIds, sizes }) => {
         } = bid;
 
         const format = adformats[i];
-        const [width, height] = sizes[i];
+        const [width, height] = expandSize(flattenSize(sizes[i]));
         const ad = createAdHtml(creativeId, format, fb_bidid);
         const requestId = requestIds[i];
 
@@ -186,9 +199,9 @@ const interpretResponse = ({ body }, { adformats, requestIds, sizes }) => {
         };
         // Video attributes
         if (isVideo(format)) {
-          const pageurl = getTopWindowUrl();
+          const pageurl = getTopWindowUrlEncoded();
           bidResponse.mediaType = 'video';
-          bidResponse.vastUrl = `https://an.facebook.com/v1/instream/vast.xml?placementid=${creativeId}&pageurl=${encodeURIComponent(pageurl)}&playerwidth=${width}&playerheight=${height}&bidid=${fb_bidid}`;
+          bidResponse.vastUrl = `https://an.facebook.com/v1/instream/vast.xml?placementid=${creativeId}&pageurl=${pageurl}&playerwidth=${width}&playerheight=${height}&bidid=${fb_bidid}`;
         }
         return bidResponse;
       });

--- a/test/spec/modules/audienceNetworkBidAdapter_spec.js
+++ b/test/spec/modules/audienceNetworkBidAdapter_spec.js
@@ -285,7 +285,7 @@ describe('AudienceNetwork adapter', () => {
       }, {
         adformats: ['native', '300x250'],
         requestIds: [requestId, requestId],
-        sizes: [[300, 250], [300, 250]]
+        sizes: ['300x250', [300, 250]]
       });
 
       expect(bidResponseNative.cpm).to.equal(1.23);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
