### PR TITLE
Check for adID 

### DIFF
--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -25,7 +25,7 @@ function receiveMessage(ev) {
     return;
   }
 
-  if (data.adId) {
+  if (data && data.adId) {
     const adObject = find(auctionManager.getBidsReceived(), function (bid) {
       return bid.adId === data.adId;
     });


### PR DESCRIPTION
Case:
When postMessage is not intended for prebid still message is being intercepted by prebid then it tries to access adId which is not valid for null object.

Put a check if data exists then only check for its property of adId