### PR TITLE
changes to support multiple sizes in format object in server adapter

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -409,7 +409,7 @@ export const spec = {
         utils.logWarn(BIDDER_CODE + ': dctr value found in more than 1 adunits. Value from 1st adunit will be picked. Ignoring values from subsequent adunits');
       }
     } else {
-      // Commenting out for prebid 1.21 release. Needs to be uncommented and changes from Prebid PR2941 to be pulled in. 
+      // Commenting out for prebid 1.21 release. Needs to be uncommented and changes from Prebid PR2941 to be pulled in.
       // utils.logWarn(BIDDER_CODE + ': dctr value not found in 1st adunit, ignoring values from subsequent adunits');
     }
 

--- a/modules/pubmaticServerBidAdapter.js
+++ b/modules/pubmaticServerBidAdapter.js
@@ -128,15 +128,17 @@ function _createImpressionObject(bid, conf) {
     banner: {
       pos: 0,
       topframe: utils.inIframe() ? 0 : 1,
+      w: bid.sizes[0][0],
+      h: bid.sizes[0][1],
       format: (function() {
         let arr = [];
-        for (let i = 0, l = bid.sizes.length; i < l; i++) {
+        for (let i = 1, l = bid.sizes.length; i < l; i++) {
           arr.push({
             w: bid.sizes[i][0],
             h: bid.sizes[i][1]
           });
         }
-        return arr;
+        return arr.length > 0 ? arr : UNDEFINED;
       })()
     },
     ext: {

--- a/test/spec/modules/pubmaticServerBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticServerBidAdapter_spec.js
@@ -224,14 +224,24 @@ describe('PubMaticServer adapter', () => {
   		  expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
   		  expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.kadfloor)); // kadfloor
   		  expect(data.imp[0].tagid).to.equal(bidRequests[0].params.adUnitId); // tagid
+        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
   		  expect(data.imp[0].banner.format[0].w).to.equal(300); // width
-  		  expect(data.imp[0].banner.format[0].h).to.equal(250); // height
-        expect(data.imp[0].banner.format[1].w).to.equal(300); // width
-        expect(data.imp[0].banner.format[1].h).to.equal(600); // height
+        expect(data.imp[0].banner.format[0].h).to.equal(600); // height
   		  expect(data.imp[0].ext.bidder.pubmatic.pmZoneId).to.equal(bidRequests[0].params.pmzoneid.split(',').slice(0, 50).map(id => id.trim()).join()); // pmzoneid
         // TODO: Need to figure why this failing
         // expect(data.imp[0].ext.adunit).to.equal(bidRequests[0].params.adUnitId); // adUnitId
         expect(data.imp[0].ext.wrapper.div).to.equal(bidRequests[0].params.divId); // div
+
+        // when sizes array has only 1 element
+        bidRequests[0].sizes = [[300, 250]];
+        request = spec.buildRequests(bidRequests);
+        data = JSON.parse(request.data);
+
+        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
+
+        expect(data.imp[0].banner.format).to.equal(undefined);
   		});
 
       it('Request params check with GDPR consent', () => {
@@ -266,14 +276,24 @@ describe('PubMaticServer adapter', () => {
   		  expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
         expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.kadfloor)); // kadfloor
         expect(data.imp[0].tagid).to.equal(bidRequests[0].params.adUnitId); // tagid
+        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
         expect(data.imp[0].banner.format[0].w).to.equal(300); // width
-        expect(data.imp[0].banner.format[0].h).to.equal(250); // height
-        expect(data.imp[0].banner.format[1].w).to.equal(300); // width
-        expect(data.imp[0].banner.format[1].h).to.equal(600); // height
+        expect(data.imp[0].banner.format[0].h).to.equal(600); // height
         expect(data.imp[0].ext.bidder.pubmatic.pmZoneId).to.equal(bidRequests[0].params.pmzoneid.split(',').slice(0, 50).map(id => id.trim()).join()); // pmzoneid
         // TODO: Need to figure why this failing
         // expect(data.imp[0].ext.adunit).to.equal(bidRequests[0].params.adUnitId); // adUnitId
         expect(data.imp[0].ext.wrapper.div).to.equal(bidRequests[0].params.divId); // div
+
+        // when sizes array has only 1 element
+        bidRequests[0].sizes = [[300, 250]];
+        request = spec.buildRequests(bidRequests, bidRequest);
+        data = JSON.parse(request.data);
+
+        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
+
+        expect(data.imp[0].banner.format).to.equal(undefined);
       });
   	});
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
