### PR TITLE
Updadted pubMatic Server adapter to have sizes in format array only a…

### DIFF
--- a/modules/pubmaticServerBidAdapter.js
+++ b/modules/pubmaticServerBidAdapter.js
@@ -128,11 +128,9 @@ function _createImpressionObject(bid, conf) {
     banner: {
       pos: 0,
       topframe: utils.inIframe() ? 0 : 1,
-      w: bid.sizes[0][0],
-      h: bid.sizes[0][1],
       format: (function() {
         let arr = [];
-        for (let i = 1, l = bid.sizes.length; i < l; i++) {
+        for (let i = 0, l = bid.sizes.length; i < l; i++) {
           arr.push({
             w: bid.sizes[i][0],
             h: bid.sizes[i][1]

--- a/modules/pubmaticServerBidAdapter.js
+++ b/modules/pubmaticServerBidAdapter.js
@@ -205,9 +205,9 @@ function _getDataFromImpArray (impData, id, key) {
         case 'requestId':
           return impData[index].id;
         case 'width':
-          return impData[index].banner.w;
+          return impData[index].banner.format[0].w;
         case 'height':
-          return impData[index].banner.h;
+          return impData[index].banner.format[0].h;
       }
     }
   }
@@ -407,8 +407,8 @@ export const spec = {
                             bidderCode: BIDDER_CODE,
                             originalBidder: summary.bidder,
                             pubmaticServerErrorCode: summary.errorCode,
-                            width: impObj.banner.w,
-                            height: impObj.banner.h,
+                            width: impObj.banner.format[0].w,
+                            height: impObj.banner.format[0].h,
                             creativeId: 0,
                             dealId: '',
                             currency: CURRENCY,

--- a/test/spec/modules/pubmaticServerBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticServerBidAdapter_spec.js
@@ -294,8 +294,6 @@ describe('PubMaticServer adapter', () => {
   		  expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
   		  expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.kadfloor)); // kadfloor
   		  expect(data.imp[0].tagid).to.equal(bidRequests[0].params.adUnitId); // tagid
-        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
         expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
         expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
   		  expect(data.imp[0].banner.format[1].w).to.equal(300); // width
@@ -310,12 +308,8 @@ describe('PubMaticServer adapter', () => {
         request = spec.buildRequests(bidRequests);
         data = JSON.parse(request.data);
 
-        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
-
         expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
         expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
-        // expect(data.imp[0].banner.format).to.equal(undefined);
   		});
 
       it('Request params check with GDPR consent', () => {
@@ -350,8 +344,6 @@ describe('PubMaticServer adapter', () => {
   		  expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
         expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.kadfloor)); // kadfloor
         expect(data.imp[0].tagid).to.equal(bidRequests[0].params.adUnitId); // tagid
-        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
         expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
         expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
   		  expect(data.imp[0].banner.format[1].w).to.equal(300); // width
@@ -366,13 +358,8 @@ describe('PubMaticServer adapter', () => {
         request = spec.buildRequests(bidRequests, bidRequest);
         data = JSON.parse(request.data);
 
-        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
-
         expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
         expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
-
-        // expect(data.imp[0].banner.format).to.equal(undefined);
       });
   	});
 

--- a/test/spec/modules/pubmaticServerBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticServerBidAdapter_spec.js
@@ -294,10 +294,12 @@ describe('PubMaticServer adapter', () => {
   		  expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
   		  expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.kadfloor)); // kadfloor
   		  expect(data.imp[0].tagid).to.equal(bidRequests[0].params.adUnitId); // tagid
-        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
-  		  expect(data.imp[0].banner.format[0].w).to.equal(300); // width
-        expect(data.imp[0].banner.format[0].h).to.equal(600); // height
+        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
+        expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
+  		  expect(data.imp[0].banner.format[1].w).to.equal(300); // width
+        expect(data.imp[0].banner.format[1].h).to.equal(600); // height
   		  expect(data.imp[0].ext.bidder.pubmatic.pmZoneId).to.equal(bidRequests[0].params.pmzoneid.split(',').slice(0, 50).map(id => id.trim()).join()); // pmzoneid
         // TODO: Need to figure why this failing
         // expect(data.imp[0].ext.adunit).to.equal(bidRequests[0].params.adUnitId); // adUnitId
@@ -308,10 +310,12 @@ describe('PubMaticServer adapter', () => {
         request = spec.buildRequests(bidRequests);
         data = JSON.parse(request.data);
 
-        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
+        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
 
-        expect(data.imp[0].banner.format).to.equal(undefined);
+        expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
+        // expect(data.imp[0].banner.format).to.equal(undefined);
   		});
 
       it('Request params check with GDPR consent', () => {
@@ -346,10 +350,12 @@ describe('PubMaticServer adapter', () => {
   		  expect(data.imp[0].id).to.equal(bidRequests[0].bidId); // Prebid bid id is passed as id
         expect(data.imp[0].bidfloor).to.equal(parseFloat(bidRequests[0].params.kadfloor)); // kadfloor
         expect(data.imp[0].tagid).to.equal(bidRequests[0].params.adUnitId); // tagid
-        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
-        expect(data.imp[0].banner.format[0].w).to.equal(300); // width
-        expect(data.imp[0].banner.format[0].h).to.equal(600); // height
+        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
+        expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
+  		  expect(data.imp[0].banner.format[1].w).to.equal(300); // width
+        expect(data.imp[0].banner.format[1].h).to.equal(600); // height
         expect(data.imp[0].ext.bidder.pubmatic.pmZoneId).to.equal(bidRequests[0].params.pmzoneid.split(',').slice(0, 50).map(id => id.trim()).join()); // pmzoneid
         // TODO: Need to figure why this failing
         // expect(data.imp[0].ext.adunit).to.equal(bidRequests[0].params.adUnitId); // adUnitId
@@ -360,10 +366,13 @@ describe('PubMaticServer adapter', () => {
         request = spec.buildRequests(bidRequests, bidRequest);
         data = JSON.parse(request.data);
 
-        expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
-        expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
+        // expect(data.imp[0].banner.w).to.equal(300); // width from 1st element of sizes array
+        // expect(data.imp[0].banner.h).to.equal(250); // height from 1st element of sizes array
 
-        expect(data.imp[0].banner.format).to.equal(undefined);
+        expect(data.imp[0].banner.format[0].w).to.equal(300); // width from 1st element of sizes array
+        expect(data.imp[0].banner.format[0].h).to.equal(250); // height from 1st element of sizes array
+
+        // expect(data.imp[0].banner.format).to.equal(undefined);
       });
   	});
 


### PR DESCRIPTION
…s per prebid page

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
