### PR TITLE
OpenWrap Release v 21.5.0 (#434)

### DIFF
--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -12,7 +12,7 @@ export const spec = {
   version: '7.1.0',
   code: BIDDER_CODE,
   gvlid: 253,
-  aliases: ['id'],
+  aliases: ['id', 'weborama'],
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 
   /**


### PR DESCRIPTION
* support for video in hybrid profiles

* added newBid.mediaType for pubmaticServerBidAdapter

* unit test case for video request

* reverted debug flag

* increment pre version

* Britepool user id module update (#5750)

* adding britepool_pubparams dynamic variable lookup and merge into submodule params if exists

* adding support for gdpr consent string in query params

* adding tests for britepool_pubparams

* adding doc block for consentData

* adding pixel on success

* - ensures id resolution pixel only fires when authoritative information is not present
 - adds tests for id resolution pixel

* Add a new param cid to bridgewellBidAdapter (#5764)

* pass a new param cid to bridgewellBidAdapter
* update the markdown file for bridgewellBidAdpter

* Refactor refererDetection to allow for URL discovery on AMP pages. (#4846)

* Refactor refererDetection to allow for URL discovery on AMP pages.

* Update import to include extension.

* Intentiq id add url params (#5771)

* Add new url params from config

* Add intentIqIdSystem_spec.js tests class

* added instream video ad support (#5766)

* added adapters for gjirafa and malltv

* interpretResponse fix for empty result

* updated testing propertyId and placementId

* added instream video ad support

* Single request for multple bids

* feat(sublimeBidAdapter): updating sublimeBidAdapter module (#5726)

- handle new notifyId parameter;
- bumping version to 0.6.0.

* Add GVL ID and bidder code to CriteoId module (#5781)

* Add GVL ID and bidder code to CriteoId module

* Add gvlid as property to CriteoIdSubmodule

Co-authored-by: Jesus Alberto Polo Garcia <ja.pologarcia@criteo.com>

* Update BrightMountainMedia cookie sync URL (#5740)

* Convert id5id to an object to support passing additional data points to platforms (#5756)

* move id5id to an object to support passing linkType and other data in the future

* update bid adapters supporting the ID5 ID to use the new object instead of a string

* remove `.only` from test

* Smaato: Support in-app use cases (#5765)

* Added GVLID to Media.net Analytics Adapter (#5789)

Co-authored-by: monis.q <monis.q@media.net>

* Add video ad support to ablida bid adapter (#5782)

* add onBidWon function, add bidder adapter version to bid requests

* add support for native

* use triggerPxel instead of ajax, because ajax was called 3 times with native

* add gdpr consent to bid requests

* update tests

* add video ad support

* Add adrelevantis adapter (#5735)

* Update adrelevantis adapter

* Update Adrelevantis Bid Adapter and Add Unit Tests

Commit changes suggested by @jsnellbaker on pull request #5735

* Adnow bidder (#5738)

* Add AdNow bid Adaptor

* Fix problems by PR comments.

* PR comments:
- Use only secure endpoint.
- Use adUnit mediaTypes instead of mediaType param in buildRequests.
- Pass correct sizes to the endpoint for banner and native.
- Fix adnowBidAdaper.md examples.
- Fix and add new tests in adnowBidAdaper_spec.js

* rename test

* Restore package-lock.json from master

* Fix sizes of bid response object for banners.

* Fix adapters tests.

* Improve error and documentation for publisherId (#5788)

- The error message you get if you use a publisherId that is a JS numeric instead of a JS string is not
  super helpful if you aren't familiar with JS internals. Update the warning message to give a suggestion
  on a solution, and update the markdown documentation to explictly state that the ID needs to be wrapped
  in quotes.

* SpotX bid adapter: add page parameter (#5784)

* Media.net Analytics improvements (#5755)

* medianetAnalyticsAdapter improvements

* medianetAnalyticsAdapter improvements

* review changes

* fixed eslint

Co-authored-by: monis.q <monis.q@media.net>

* adagio Bid Adapter: add support for CCPA, COPPA (#5749)

Co-authored-by: Clément besse <clement.besse@gmail.com>

* PubMatic analytics adapter: Not passing GDPR information (#5791)

* added support for pubcommon, digitrust, id5id

* added support for IdentityLink

* changed the source for id5

* added unit test cases

* changed source param for identityLink

* not passing GDPR data in analytics

* GumGum: adds support for new field - iriscat (#5790)

* adds support for zone and pubId params

* adds support for iriscat field

* fix a few id5 docs (#5793)

* update id5 eids value and add html storage example

* html5, not html

* New PubProvided Id UserId Submodule (#5767)

* PubProvided Module

* -

* formatting

* formatting

* Added rubiconBidAdapter support
Added unit tests

* formatting

* formatting

* formatting

* formatting

* commit to rerun build

* type changes

* type changes

* type changes

* Revert "type changes"

This reverts commit af408b0a

* Revert "type changes"

This reverts commit af408b0a

* formatting

* formatting

* formatting

* formatting

* formatting

* Revert "type changes"

This reverts commit 114005a5

* formatting

* formatting

* formatting

* formatting

* commit to rerun build

* commit to rerun build

* commit to rerun build

* rubiconBidAdapter changes

* rubiconBidAdapter changes

* rubiconBidAdapter changes

* trigger build

* fix

* fix

* fix

* rebuild

Co-authored-by: myerkovich <myerkovich@rubiconproject.com>

* standardize rubicon get config calls (#5780)

* Prebid 4.10.0 Release

* Increment pre version

* Add Inmar bidder adapter (#5674)

* Add Inmar bidder adapter

* Update Inmar adapter

* Small fix

* Update Inmar params

* Remove domain and bidFloor, add meta

* Remove unused data

* Fix unit tests

* added detect referer (#5759)

Co-authored-by: Ignat Khaylov <khaylov@betweenx.com>

* Qwarry bid adapter (#5662)

* qwarry bid adapter

* formatting fixes

* fix tests for qwarry

* qwarry bid adapter

* add header for qwarry bid adapter

* bid requests fix

* fix tests

* response fix

* fix tests for Qwarry bid adapter

Co-authored-by: Artem Kostritsa <akostritsa@akostritsa.com>
Co-authored-by: Alexander Kascheev <akascheev@asteriosoft.com>

* Allow selection of supported default targeting keys at configuration time. (#5763)

* initial check-in: add ability to selectively allow default keys into GAM KV targeting.

* add more descriptive test documentation to explain that the default targeting keys is checking against the key prefix to accomodate bid landscape.

collate and remove targeting surrounding the key removal process.

* cointrafficBidAdapter: added support responding in different currencies (#5800)

* New adapter "Cointraffic" added

* removed mobile detection

* The sizes property has been updated, added supportedMediaTypes.

* feat: added support responding in different currencies

* change: module description

* Send proper slot info in case of adUnitPath (#5810)

- using `getGptSlotInfoForAdUnitCode` to get `divId` in case of `adUnitPath`
- added test case for visibility via `adUnitPath`

Co-authored-by: monis.q <monis.q@media.net>

* Update to rubiconBidAdapter to include criteoId support (#5806)

* appnexus bid adapter: criteo back to tpuids (#5808)

* Intentiq id add validation (#5797)

* Add validity check to ignore not-available response

* Added tests

* Added error log

* remove digitrust from rubicon bid adapter (#5798)

* add native preset handling and automatic price macro replacement (#5807)

Co-authored-by: Maxime Lequain <maxime.lequain@adotmob.com>

* fix some video request params (#5799)

* expose full user id config (including storage) to user id modules (#5803)

* expose full user id config (including storage) to user id modules, rather than just the params object

* update docs to `SubmoduleConfig`

* more doc fixes

* missed one doc

* Fix timeToFirstByte unit test (#5820)

* Debug timeToFirstByte unit test

* review

* rubicon: adding pubcid support (#5824)

* rubicon: adding pubcid support

* adding to orderedParams

* removed eids filter so all eids will be supported

* fix eids test

* fixed eids assertions

Co-authored-by: Isaac A. Dettman <idettman@rubiconproject.com>

* Changes for UOe-5712/5705

* Appnexus: Add omid support (#5821)

* basic implementation complete

* add unit tests

* remove redundant field tags[].video.frameworks

* new userId module - neustar's fabrick (#5802)

* submitting userId module for neustar's fabrick - https://www.home.neustar/fabrick

* fixing 'gulp test' errors

* fixing another test issue (related to ie)

* removing another (last) repeat

* - expose full user id config (including storage) to user id modules (#5803
- removing TODO from test

* - updates to test

Co-authored-by: Anderson, Ben <Ben.Anderson@team.neustar>

* Integrate option to pass clickThrough urls to renderAd method (#5796)

* adding options to renderAd method

* adding replaceClickThrough method to utils

* implemented replaceClickThrough method in render ad to enable ssps adding url param clickthrough for publisher side counting

* update to cover some validation and unit tests as requested by harpere

* adding unit test for clickthrough implementation;

* Add credentials and explicit options to CriteoIdSystem (#5822)

Co-authored-by: Hugo Duthil <h.duthil@criteo.com>

* AdYouLike bidAdapter - Add information in bid request (#5828)

* Remove useless bidderCode in bid response

* send all the available sizes in the bid request

* Use the banner sizes if given

* avoid compatibility issue with old bid format

* ad iframe and publisher domain paramters to bid requests

* add publisher domain info in ad request

* add a check in unit tests for publisherDomain

* encode uri components

Co-authored-by: Guillaume <guiandouard@gmail.com>

* 4.11.0 release

* 4.12.0-pre

* IDx user id submodule (#5826)

* add idx user id

* Update modules/idxIdSystem.js to match new SubmoduleConfig param

Co-authored-by: Scott <smenzer@gmail.com>

Co-authored-by: Scott <smenzer@gmail.com>

* Adding Test mode for the IronSource bidder (#5831)

* Change ironsource to be lower case all over code

* Add test mode to the IronSource bidder

* Manually took the changes for DVC related info

* Adtelligent: Add new alias (#5825)

* Add vuukle adapter (#5773)

* add vuukle adapter

* add readme

* doc: add email

* Handling video outstream in smartadserver adapter. (#5739)

* Handling video outstream in smartadserver adapter.

* Fixing the outstream example with the queue handler.

Co-authored-by: tadam <tadam@smartadserver.com>

* add stroeerCoreBidAdapter (#5830)

* add stroeerCoreBidAdapter

* test correction

* refactroring

* add gvl id to spec

Co-authored-by: Jakub Dlouhý <jakub.dlouhy@ibillboard.com>
Co-authored-by: karel koule <koulekarel@gmail.com>
Co-authored-by: Lukáš Havrlant <lukas.havrlant@gmail.com>

* Added the ability to send multiple bids in one ad request for mediaforce bid adapter (#5834)

* Added the ability to send multiple bids in one ad request for mediaforce bid adapter

* Fixes after review for mediaforce bid adapter

* Force refresh userId (#5819)

* Added global function for refreshing user id's

* Refactored submodule initialization to allow for refresh

* Added submodule initialization when refreshing user id's

* Refactored refresh parameter to be optional

Refactored refresh user id's parameter to be optional where an empty list will result in all modules being refreshed.

* Added unit tests for refresh user id's

* Added single module refresh test

* Test callback in refreshUserIds test

* Remove zeotapIdPlus expiration on cookie in test because it caused it to intermittently fail

Co-authored-by: chammon <chammon@rubiconproject.com>

* Hybrid adapter. Added support In-Image format (#5754)

* Added Hybrid.ai adapter

* Is used 'find' from 'core-js/library/fn/array/find' instead Array.find

* Fixed missing file extensions for imports

* Typo fixed

* Fixed missing file extensions for imports

* Added support In-Image format

* Added more test

* Fixed errors of lint

* Deleted debug line

Co-authored-by: s.shevtsov <s.shevtsov@targetix.net>

* PubMatic Analytics: internal kgpv param support in analytics (#5849)

* added support for pubcommon, digitrust, id5id

* added support for IdentityLink

* changed the source for id5

* added unit test cases

* changed source param for identityLink

* not passing GDPR data in analytics

* adding support for OpenWrap regex support

* added unit test cases

* TrueReach Bidder Adapter: Added User Sync Support (#5846)

* Added Trureach Prebid Adapter

* cleaned up truereach bidder adapter for release

* truereach bidder adapter md file for release

* [truereach] bidder adapter and md files update. bidderUrl no more configurable.

* [Prebid] supporting nurl

* [Prebid] changes required due to code style

* [Prebid] prebid unit test

* [Prebid] added advertiserDomains in response object

* [Prebid] Secure Bidder Url.

* Added usersync support

* changes in bidder url

Co-authored-by: Nitin Kumar <nitin.kumar@momagic.com>
Co-authored-by: arnav <arnav.mishra@momagic.com>
Co-authored-by: arnav <arnav.mishra@momgaic.com>

* Don't parse the querystring when extracting the protocolHost (#5851)

Co-authored-by: Karim El Shabrawy <k.elshabrawy@criteo.com>

* Add rubicon size 548 (#5853)

* Rubicon Adapter: Add multiple sizes to sizeMap

* Add new size 500x1000 (ID: 548) in Rubicon Adapter

Co-authored-by: Bret Gorsline <bgorsline@rubiconproject.com>

* PR Review Process: Adding RTD, UserId. General modernization. (#5829)

* Adding RTD, UserId. General modernization.

* Update PR_REVIEW.md

Co-authored-by: Scott Menzer <scott@id5.io>

Co-authored-by: Scott Menzer <scott@id5.io>

* ATS-analytics - add retry logic to not fire request for envelope every time, and cut down analytics requests to 1/10 (#5839)

* ATS-analytics - add retry logic to not fire request for envelope every time, and cut down analytics requests to 1/10

* ATS-analytics - fix test naming

* Add examples and tests for criteo User Id Module (#5838)

Co-authored-by: Hugo Duthil <h.duthil@criteo.com>

* Fix size validate (#5841)

* add relaido adapter

* remove event listener

* fixed UserSyncs and e.data

* fix conflicts

* updated size validate

Co-authored-by: cmertv-sishigami <s.ishigami@cmertv.com>

* fix adunit.bid undefined edge case (#5827)

* PubMatic Analytics: pass device platform related information (#5855)

* added support for pubcommon, digitrust, id5id

* added support for IdentityLink

* changed the source for id5

* added unit test cases

* changed source param for identityLink

* not passing GDPR data in analytics

* adding support for OpenWrap regex support

* added unit test cases

* passing device platform in logger call; test cases added

* Prebid 4.12.0 Release

* git commit -m "Increment pre version"

* add ooloAnalyticsAdapter (#5852)

* oolo analytics adapter added

* update md

* fix startsWith undefined

* adjust tests

* update tests - replace .find with .filter

* update .md description

* Add sharedid support to pubcommon (#5850)

* Add sharedid support to pubcommon

* Add sharedid support to pubcommon - fix typos

* Add sharedid support to pubcommon - delete sharedid cookie when opt-out

* Add sharedid support to pubcommon - disable sharedid by default

* Fix Typo

* PR Review process tweaks (#5862)

Incorporating feedback

* Added basic support for ID Module (#5835)

Co-authored-by: John Rosendahl <jrosendahl@gmailcom>

* Rename pubProvidedSystem.js to pubProvidedIdSystem.js (#5861)

* Rename pubProvidedSystem.js to pubProvidedIdSystem.js

* Update userId_spec.js

* Adding Medianet outstream renderer support (#5854)

* PR-review: fixed getFloor function name (#5876)

* Real Time Data Module - Phase3 (#5783)

* real time data module,
browsi sub module for real time data,
new hook bidsBackCallback,
fix for config unsubscribe

* change timeout&primary ad server only to auctionDelay
update docs

* support multiple providers

* change promise to callbacks
configure submodule on submodules.json

* bug fixes

* use Prebid ajax

* tests fix

* browsi real time data provider improvements

* real time data module,
browsi sub module for real time data,
new hook bidsBackCallback,
fix for config unsubscribe

* change timeout&primary ad server only to auctionDelay
update docs

* support multiple providers

* change promise to callbacks
configure submodule on submodules.json

* bug fixes

* use Prebid ajax

* tests fix

* browsi real time data provider improvements

* RTD module extend #4610

* add hook for submodule init
variables naming

* RTD bug fix

* remove auction delay and related hooks

* RTD phase 3

* design changes

* fix loop continuation

* proper fix this time

* linter

* reduce loops

Co-authored-by: bretg <bgorsline@gmail.com>

* Audigent RTD Provider HaloId Support & RTD Phase 3 Compliance (#5777)

* real time data module,
browsi sub module for real time data,
new hook bidsBackCallback,
fix for config unsubscribe

* change timeout&primary ad server only to auctionDelay
update docs

* support multiple providers

* change promise to callbacks
configure submodule on submodules.json

* bug fixes

* use Prebid ajax

* tests fix

* browsi real time data provider improvements

* real time data module,
browsi sub module for real time data,
new hook bidsBackCallback,
fix for config unsubscribe

* change timeout&primary ad server only to auctionDelay
update docs

* support multiple providers

* change promise to callbacks
configure submodule on submodules.json

* bug fixes

* use Prebid ajax

* tests fix

* browsi real time data provider improvements

* RTD module extend #4610

* add hook for submodule init
variables naming

* RTD bug fix

* remove auction delay and related hooks

* update audigent rtd provider

* style update

* change onDone() logic

* RTD phase 3

* return on data unavailable

* api endpoint update

* update audigent RTD provider for new spec

* design changes

* fix loop continuation

* proper fix this time

* linter

* update rtd parameters, onDone semantics

* reduce loops

* documentation update

* working update to rtd3 spec, update segment example, documentation

* remove unused vars, reference module name

* resolve haloid for segments

* update documentation to markdown

* update description in documentation

* minify optimizations

Co-authored-by: omerdotan <omerdo@gobrowsi.com>
Co-authored-by: bretg <bgorsline@gmail.com>

* [AD-963] - Update JW Player RTD Provider for compliance with RTD Module Phase 3 (#5844)

* updates grid adapter

* adds response to bids

* separates responsibilities

* refactos success block

* renames functions

* tests getCache and formatting

* tests data enrichment

* adds tests for bid enhancement

* updates documentation

* adds clarification that sample params are placeholders

* adds instructions to replace placeholder ids in example

Co-authored-by: karimJWP <karimJWP@github.com>

* Reconciliation Real Time Data Provider (#5774)

* FID-162: Add Reconciliation RTD Provider

* FID-162: Update Reconciliation RTD Provider API

* FID-162: Update getTargetingData method

* FID-162: Add tests

* Update instream logic to account for multimp (#5872)

* initial commit, instream poc done

* push in poc changes

* push in poc changes

* restore instream.html

* push in poc changes

* restore instream.html

* restore instream.html v2

* adding instream unit tests v1

* catch up to bidfloor changes

* unit tests finalized!

* update adapter md

* add support for mediaTypes.video

* merge in prebid master

* add instream validation

* add unit test for instream validation

Co-authored-by: Sy Dao <iam.sydao@gmail.com>

* Verizon Media user id module (#5786)

* Initial work on Verizon Media User ID module

* Submodule tests

* Add sample eid object for Verizon Media

* Documentation update

* Switch to HTTP GET, update tests.

* Remove single test restriction.

* Documentation update

* Addressing initial PR feedback.

* Accept pixelId parameter to construct VMUID URL

* Fix tests following API signature change

* Add IAB vendor ID

Co-authored-by: slimkrazy <sam@slimkrazy.com>

* Use new ad request format by default in TheMediaGrid Bid Adapter (#5840)

* The new request format was made by default in TheMediaGrid Bid Adapter

* Update userId format in ad request for TheMediaGrid Bid Adapter

* Added bidFloor parameter for TheMediaGrid Bid Adapter

* Fix for review TheMediaGrid Bid Adapter

* Support floorModule in TheMediaGrid Bid Adapter

* Floors Module update to include floorMin (#5805)

* Update to floors module to allow floorMin definition using setConfig({floors:...});
1) If floorMin exists, set floorValue to new property floorRuleValue.
2) If floorMin is greater than floorValue, set floorValue to floorMin.

Update to Rubicon Analytics Adapter to pass floorMin under auction.floors.floorMin if exists. Also includes update to pass floorRuleValue for each bid if floorMin exists

Update to floorsModule roundup functionality to fix to one decimal place prior to roundup. This will fix issues in which JS evalutates a whole number to include a very small decimal value that forces a roundup to the next whole number.

* Remove extra spaces

* Package Lock revert

* Updates to commit

* Remove comment

* Remove excess spaces

* Update to priceFloor and rubiconAnalytics adapters

* Prebid 4.13.0 Release

* Increment pre version

* configurable TTL for impressions (#5880)

* PulsePoint Adapter: Fix on multi-format support (#5857)

* ET-1691: Pulsepoint Analytics adapter for Prebid. (#1)

* ET-1691: Adding pulsepoint analytics and tests for pulsepoint adapter

* ET-1691: Adding pulsepoint analytics and tests for pulsepoint adapter

* ET-1691: cleanup

* ET-1691: minor

* ET-1691: revert package.json change

* Adding bidRequest to bidFactory.createBid method as per https://github.com/prebid/Prebid.js/issues/509

* ET-1765: Adding support for additional params in PulsePoint adapter (#2)

* ET-1850: Fixing https://github.com/prebid/Prebid.js/issues/866

* Minor fix

* Adding mandatory parameters to Bid

* APPS-3774

* ID5 user id module: migrate publishers to use local storage instead of 1p cookies (#5874)

* change storage name

* id5 user id module will now prefer localstorage over cookies with a specific name.
- for now, the requirement is a warning, but in a future release it will be a strict requirement and the module will not work if it's not configured properly by the publisher
- remove code to support legacy endpoint / storage since all publishers using ID5 have upgraded past v3.25.0
- once a publisher is using localstorage, remove any legacy cookies that are not longer needed

* add id5 markdown file

* update example docs to use html5 and new storage name

* add todo

* code review updates

* update version

* doc tweaks

* doc tweaks

* address PR feedback
- fix bug in storage expiration dates
- remove unnecessary check

* add us_privacy to id5 id module (#5858)

* Rubicon Bid Adapter - Interpret response adds new meta values (#5864)

* [Synacormedia] Config override for site.domain property (#5885)

* CAP-1992 - use get config for site.domain

* AOL Adapter: User ID Support (#5886)

* Added support for passing VMUID to SSP endpoints

* Remove 'only' command

* Do not create user.ext object unless required

* Add support for passing Liveramp envelope to VM SSP

* WIP

* Updated tests

* Remove trailing comma

Co-authored-by: slimkrazy <sam@slimkrazy.com>

* the code to require local storage will be released in 4.14.0 not 4.13.0 (#5889)

* piid for hybrid profiles

* fix: schain complete can be 0 (#5902)

* [AD-1020] JWPlayer RTD: Obtain targeting params from FPD (#5892)

* reads jwTargeting from fpd

* refactors param extraction

* updates documentation

* mentions support of config fpd

* reduces auction delay examples

Co-authored-by: karimJWP <karimJWP@github.com>

* Add support for Publisher Common ID Module (#5871)

- New user id value to be sent to STR Ad Server as `pubcid` of the bid request object

Story: [#175125639](https://www.pivotaltracker.com/story/show/175125639)

* Liveintent id module doesn't fall back to the default implementations of ajax, pixel and storage. (#5859)

Liveintent id module reads an email hash that is provided in the configuration.

* removed fix for piid from staged_nightly

* aol bid adapter: support IE (#5894)

* support IE in aol spec

* array includes not supported IE11

* add check for config to make sure its defined (#5873)

* Prebid 4.14.0 Release

* Increment pre version

* Media type renderers (#5760)

* allow publisher to define a renderer specific to the mediaType

* validate outstream bid with a renderer defined on the video mediaType

* get the mediaTypes from the bidReqest

* tests for publisher-defined, media-specific renderers

* use single quote

* undo inadvertent package-lock.json changes

Co-authored-by: Michael Sperone <msperone@usnews.com>

* Added GVL_ID & addtl_consent for smartadserverBidAdapter (#5870)

* SIM-875 Adding GVL_ID

* SIM-875 Added addtl_consent

* SIM-875 removing trailing whitespaces

* New krushmedia Prebid.js adapter (#5833)

* inital

* fix

* fix

* fix

* fix

* fix

* fix

* add maintener to md

* Added native support

Co-authored-by: Aiholkin <artem.iholkin@smartyads.com>

* eTarget: adapter update (#5881)

* adapter update

Send response reason

* Update etargetBidAdapter.js

Adding optional response parameter

* Update etargetBidAdapter_spec.js

* DMX Fix video bug (#5910)

* adding DMX

test @97%, two files added one updated

* Update districtm_spec.js

* Update districtmDMX.js

* adding all districtm needed file

* remove legacy file

* remove typo || 0 in the test method

* force default to return a valid width and height

* update unit test code for failing test

* changed class for an object

* remove package-lock.json

* change file name for dmx adapter

* renamed files

* restaure package-lock.json

* update to last package-lock state

* update gdpr user consent

* fix sizes issue

* Documentation updates

Adding the readme.md info

* update file name and update unit testing import file location

* current machine state

* lint correction

* remove variable assigment duplicate

* adding CCPA support for DMX

* adding test for ccpa and gdpr

* districtm dmx adding deal id field

* idsync support ccpa & gdpr

* fix error on vast response that failed

Co-authored-by: Steve Alliance <steve@districtm.ca>
Co-authored-by: Luis <luissastreverzun@gmail.com>
Co-authored-by: Steve Alliance <stevealliance@Steves-Air.localdomain>
Co-authored-by: Steve Alliance <stevealliance@Steves-MacBook-Air.local>
Co-authored-by: steve-a-districtm <steve@districtm.net>

* fix failing lint errors on circle ci (#5918)

* sspId for pubmatic only (#418)

* IX missing sizes testing and diagnosis (#5856)

* Added support for Liveramp userId submodule

* Fixing URL length for large requests

* adding telemetry to missing sizes feature

* adding markdown file with detectMissingSizes

* example value update

Co-authored-by: IX-Prebid-Support <ix-prebid-support@indexexchange.com>

* Add apacdex bid adapter & Merge valueimpression, quantumdex to apacdex (#5888)

* Adkernel: basic meta forwarding (#5836)

* Add skip params to Beachfront adapter (#5847)

* feat: add skip params and standard params to video bid request

* refactor: add props to exclude list

* refactor: bump adapter version

Co-authored-by: John Salis <johnsalis@beachfrontmedia.com>

* AMX RTB: improve URL handling in request (#5905)

* feat: add the elapsed time to events for debugging (#5868)

* feat: add the elapsed time to events for debugging

* naming

* remove 'only' to run all tests (#5926)

* Add Auction Options Config (#5787)

* feature/auction-timing

* rename to auctionOptions

* move filtering outside of loop and organized logic.

* remove auctionOptions test page

* TL: Add GVLID, update validation method, add unit tests (#5904)

* Add IdentityLink support and fix UnifiedId.

It appears we've been looking for UnifiedId userIds
on the bidderRequest object, when they are found on bidRequests.
This commit fixes that error, and adds support for IdentityLink.

* change maintainer email to group

* TripleLift: Sending schain (#1)

* Sending schain

* null -> undefined

* Hardcode sync endpoint protocol

* Switch to EB2 sync endpoint

* Add support for image based user syncing

* Rename endpoint variable

* Add assertion

* Add CCPA query param

* Simplify check for usPrivacy argument

* put advertiser name in the bid.meta field if it exists

* update unit tests with meta.advertiserName field

* Triplelift: FPD key value pair support (#5)

* Triplelift: Add support for global fpd

* don't filter fpd

* adds coppa support back in

* add gvlid, update validation method, add unit tests

* remove advertiserDomains logic

* typo

* update _buildResponseObject to use new instream validation

Co-authored-by: Will Chapin <wrchapin@gmail.com>
Co-authored-by: colbertk <50499465+colbertk@users.noreply.github.com>
Co-authored-by: David Andersen <davidwoodsandersen@gmail.com>
Co-authored-by: Brandon Ling <bling@triplelift.com>
Co-authored-by: colbertk <kcolbert@triplelift.com>
Co-authored-by: Kevin Zhou <kzhou@triplelift.com>
Co-authored-by: kzhouTL <43545828+kzhouTL@users.noreply.github.com>
Co-authored-by: Sy Dao <iam.sydao@gmail.com>

* rubicon - support all userIds (#5923)

* rubicon - support all userIds

* rubicon - support all userIds update

* rubicon update to userId logic

Co-authored-by: Eric Harper <eharper@rubiconproject.com>

* Adds tcf v2 support (#5883)

Co-authored-by: francesco <f.orazini@onetag.com>

* get dynamic ttl from the server response (#5896)

* Change ironsource to be lower case all over code

* Add test mode to the IronSource bidder

* get dynamic ttl from the server response

* Teads adapter: add Global Vendor Id (GDPR enforcement) (#5929)

* Smaato: Add userIds to BidRequest (#5927)

* Mediasquare: add native and video support (#5823)

* Mediasquare: Add support for uspConsent + schain userIds support. Plus enhance userSync

* fix iframeEnabled and pixelEnabled + suggested shortand statement

* mediasquare bidder: add metrics to onBidWon Event

* mediasquare bidder: fix getUserSyncs

* MediaSquare: add native and video support

* 33Across: Added Video Support (#5884)

* check gdpr in buildRequest

* User sync based on whether gdpr applies or not

* check if consent data exists during user sync

* split user sync into further branches: 1) when gdpr does not apply 2) when consent data is unavailable

* contribute viewability to ttxRequest

* update tests

* remove window mock from tests

* use local variables

* introduce ServerRequestBuilder

* add withOptions() method to ServerRequestBuilder

* add semicolons

* sync up package-lock.json with upstream/master

* stub window.top in tests

* introduce getTopWindowSize() for test purpose

* reformat code

* add withSite() method to TtxRequestBuilder

add withSite() method to TtxRequestBuilder

* add isIframe() and _isViewabilityMeasurable()

* handle NON_MEASURABLE viewability in nested iframes

* consider page visibility, stub utils functions getWindowTop() and getWindowSelf()

* contribute viewability as 0 for inactive tab

* add prebidjs version to ttx request

* send caller as an array

* send viewability as non measurable when unable to locate target HTMLElement, add warning message

* fix JSDoc in utils.js

* introduce mapAdSlotPathToElementId()

* introduce getAdSlotHTMLElement(), add logging

* introduce mapAdSlotPathToElementId()

* update logging in ad unit path to element id mapping

* rephrase logging, fix tests

* update adapter documentation

* remove excessive logging

* improve logging

* revert change

* fix return of _mapAdUnitPathToElementId()

* improve logging of _mapAdUnitPathToElementId()

* do not use Array.find()

* return id once element is found

* return id once element is found

* let -> const

* Removing killswitch behavior for GDPR

* Updated comments to reflect current gdpr logic

* URI encode consent string

* Updated example site ID to help Prebid team e2e test our adapter

* send page url in ortb

* Removed redundant pageUrl default

* Restored package-log.json that mirrors prebid's repo

* Sending USP string during buildRequest

* Adding USP consent data to user sync

* add unit test for syncing without bidrequest

* Changed to uspConsent to make the connatation consistent

* Resetting adapter state in adapter after user sync rather than exposing it.

* removed console log

* Adding schain info

* remove setting empty format ext

* better tests invalid values

* removing validation of schain

* Fixed lint errors

* First cut for bidfloors support

* fixed where getFloors is read

* fixed merge conflicts

* support the guid in the api endpoint

* Reformat + validation updates

* refactor banner to conform to mediaType format

* Building video ORTB

* code review changes for better refactor

* Building video ORTB

* Interpret video response

* Updated documentation

* Updated supported mediatypes

* Added bidfloors

* Adding support bidder specific overrides

* only validate startdelay when instream

* fixed incorrect params for instream

* Removed usage of an actual GUID for safety.

* Added mimes and protocols as required

* placement is +ve int

* fix for sizes + valid sample GUID

Co-authored-by: Gleb Glushtsov <gleb.glushtsov@33across.com>
Co-authored-by: Gleb Glushtsov <glebglushtsov@users.noreply.github.com>
Co-authored-by: Gleb Glushtsov <gleb.glushtsov@gmail.com>
Co-authored-by: Aparna Hegde <ahegde@pool-10-1-150-29-nyc.internal.33across.com>
Co-authored-by: Aparna Hegde <ahegde@admins-MacBook-Pro.local>
Co-authored-by: Aparna Hegde <ahegde@pool-10-1-150-137-nyc.internal.33across.com>
Co-authored-by: Aparna Hegde <ahegde@pool-10-1-150-96-nyc.internal.33across.com>
Co-authored-by: Aparna Hegde <ahegde@AHEGDE-MAC.local>
Co-authored-by: Aparna Hegde <ahegde@AHEGDE-MAC.fios-router.home>
Co-authored-by: terryc33x <64039851+terryc33x@users.noreply.github.com>
Co-authored-by: Terry Chen <terry.chen@33across.com>

* Prebid 4.15.0 Release

* Increment pre version

* Improve Digital adapter: eids support (#5935)

* Improve Digital adapter: eids support

* Fix quotes

* Adkernel: andbeyond alias (#5922)

* fix to remove redundant validation for datatype for partner value - UOE-5788

* fix for UOE-5788

* LunamediaHB bid adapter (#5906)

* Add User ID Targeting to googletag.cmd as a fallback when GPT API is not ready (#5925)

* Add User IDs to googletag.cmd

The purpose of this change is to allow the userIdTargeting module to function even when googletag has not been defined yet.

* Fixing indentation errors

Fixing indentation errors thrown by

* Fix 'googletag' is not defined errors

* Added unit test for userIdTargeting fallback

* No bid version 1.2.9 (#5794)

* Enable supplyChain support

* Added support for COPPA

* rebuilt

* Added support for Extended User IDs.

Co-authored-by: Reda Guermas <reda.guermas@nobid.io>

* EMX Adding Schain forwarding (#5946)

* adding ccpa support for emx_digital adapter

* emx_digital ccpa compliance: lint fix

* emx 3.0 compliance update

* fix outstream renderer issue, update test spec

* refactor formatVideoResponse function to use core-js/find

* Add support for schain forwarding

Co-authored-by: Nick Colletti <nick.colletti@emxdigital.com>
Co-authored-by: Nick Colletti <gnomish@gmail.com>
Co-authored-by: Kiyoshi Hara <Kiyoshi.Hara@emxdigital.com>
Co-authored-by: Dan Bogdan <daniel.bogdan@emxdigital.com>
Co-authored-by: Jherez Taylor <jherez.taylor@emxdigital.com>
Co-authored-by: EMXDigital <emxdigital@emxdigital.com>

* pubGENIUS bid adapter: fix bug that requestBids timeout is not respected (#5940)

* fix requestBids timeout

* fix pubgenius bid adapter test

* Updated the text in line 292 (#5937)

Updated the text in line 292

* Update for Qwarry bid adapter (#5936)

* qwarry bid adapter

* formatting fixes

* fix tests for qwarry

* qwarry bid adapter

* add header for qwarry bid adapter

* bid requests fix

* fix tests

* response fix

* fix tests for Qwarry bid adapter

* add pos parameter to qwarry bid adapter

Co-authored-by: Artem Kostritsa <akostritsa@akostritsa.com>
Co-authored-by: Alexander Kascheev <akascheev@asteriosoft.com>

* moved changes for UOE-5788 in hasRequiredParams function

* Adagio Bid Adapter: support UserId's (#5938)

* userId module: fix auctionDelay submodules with callbacks (#5891)

* clearTimeout only after all submodules are done

* check that setTimeout function was not cleared

* fix circle ci failing lint error (#5952)

* PR-Review process: fleshing out RTD review (#5948)

* PR-Review process: fleshing out RTD review

* align bidrequest attribute

* delete pubcommon test cookie for domainOverride after writing it in all cases (#5943)

* delete pubcommon test cookie after writing it in all cases, not just when it is found again

* fix lunamediahbBidAdapter lint issue

* call domainOverride only when needed in the module, not ahead of time when the module is registered.

* Gamoshi - Add new alias (#5895)

* add logic to prefer prebid modules over external modules in build process (#4124)

* add check in getModules helper function

* update logic based on feedback

* update node version of project

* Improve Digital adapter: adding bid floor, referrer, more native fields (#4103)

* Bid floor, https, native ad update

* Update the ad server protocol module

* Adding referrer

* YIELDONE adapter - change urls to adapt https (#4139)

* update: change urls to adapt https

* fix test code

* Added SupplyChain Object support and an onTimeout Callback (#4137)

* - Implemented the 'onTimeout' callback to fire a pixel when there's a timeout.
- Added the ability to serialize an schain object according to the description provided here: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md

* some mods to the schain tag generation

* - added tests for schain param checking.

* - fixed a malformed url for timeouts

* - Removed a trailing ',' while generating a schain param.

* Revert "Added SupplyChain Object support and an onTimeout Callback (#4137)"

This reverts commit e61b246b45bd2c2390350eaeca693f208b1a3a24.

This commit doesn't use the schain module added in #4084

* Nobid Prebid Adapter commit (#4050)

* Nobid Prebid Adapter commit

* Fixed global replace and unit tests

* Fixed find function

* Added nobidBidAdapter.md

* Removed description and added "Bid Params" section.

* Added test siteId 2 for testing.

* Refactored the Adapter to remove most references to the nobid object. We still need the nobid object because we have a passback tag in DFP that makes reference to it.

* Fix concurrent responses on the page

* Cosmetic change to log an error in case of missing ad markup

* Keep nobid.bidResponses cross adapters.

* Added GDPR support in user sync and added test coverage.
gulp test-coverage
gulp view-coverage

* Padding issues

* Fix padding issues

* Fix padding

* update outstream prod url (#4104)

* support pubcid and uids (#4143)

* Fix misspelling and minor cleanup of schain docs (#4150)

* Prebid 2.31.0 Release

* Increment pre version

* Rubicon: tuning logged messages (#4157)

* Rubicon: tuning logged messages

* Update rubiconBidAdapter.js

* fixed indentation

* Rubicon Video COPPA fix (#4155)

* Rubicon Video COPPA fix

* Unit test for Rubicon Video COPPA fix

* Playground XYZ adapter - iframe usersync bug fix (#4141)

* corrected user sync type

* removed support for iframe usersync

* added unit tests for getUserSyncs

* update nvmrc file (#4162)

* update gulp-footer package (#4160)

* Datablocks bid/analytics adapter (#4128)

* add datablocks Analytics and Bidder Adapters

* remove preload param

* remove preloadid

* better coverage of tests

* better coverage

* IE doesn't support array.find

* lint test

* update example host

* native asset id should be integer

* update logic of ad_types field in appnexusBidAdapter (#4065)

* Shorten SomoAudience to just Somo (#4163)

* Shorten SomoAudience to just Somo

* Make package-lock return

* Quantcast: Fix for empty video parameters (#4145)

* Copy params from bid.params.video.

* Added test for missing video parameters.

* Include mimes from adunit.

* One Video adding Rewarded Video Feature (#4142)

* outstream changes

* removing global filtet

* reverting page

* message

* adapter change

* remove space

* testcases

* testpage

* spaces for test page

* renderer exist case

* reverting package-lock.json

* adding schain object

* adding tagid

* syntaxx error fix

* video.html

* space trailing

* space

* tagid

* inventoryId and placement

* rewarded video

* added unit test case

* Module to pass User Ids to DFP (#4140)

* first commit

* renamed

* minor doc change

* documentation

* small change

* EB

* removed unused imports

* minor changes

* reanmaed a const

* adding more methods to test shareUserIds module

* unit tets cases for shareUserIds

* indentation

* renamed DFP to GAM

* renamed shareUserIds to userIdTargeting

* Update userIdTargeting.md

* trying to restart CI

* digitrust userId case handled

* minor comment change

* using auctionEnd event instead of requestBids.before

* using events.on

* Buzzoola bid adapter (#4127)

* initial commit for buzzoola adapter

* leave only banners for now

* fix bid validation

* change endpoint url

* add video type

* restore renderer

* fix renderer

* add fixed player sizes

* switch bids

* convert dimentions to strings

* write tests

* 100% tests

* remove new DOM element creation in tests

* handle empty response from server

* change description

* E2e tests for Native and Outstream video Ad formats. (#4116)

* reorganize e2e/ tests into separate directories

* new test page for e2e-banner testing

* add test to check if Banner Ad is getting loaded

* change location of the spec files to reflect change in test/e2e directory structure

* add test case to check for generation of valid targeting keys

* create Native Ad test page

* add test case to check validity of the targeting keys and correct rendering of the Ad

* update old browser versions to new

* update browser version

* update title

* remove console.log statements

* add basic functional test for e2e outstream video ad format

* Update LockerDome adUnitId bid param (#4176)

This is not a breaking change

* fix several issues in appnexus video bids (#4154)

* S2s testing disable client side (#4123)

* Add microadBidAdapter

* Remove unnecessary encodeURIComponent from microadBidAdapter

* Submit Advangelists Prebid Adapter

* Submit Advangelists Prebid Adapter 1.1

* Correct procudtion endpoint for prebid

* analytics update with wrapper name

* reverted error merge

* New testServerOnly flag

* Tests and a bug fix

* Removed dead code

* Fixes requested in review

* Check each adUnit

* isTestingServerOnly changes per Eric

* Fixed IE 11 bug

* More tests

* improved test case names

* New option to Include deal KVPs when enableSendAllBids === false (#4136)

* new option to include KVPs which have deals when
enableSendAllBids === false

* updating tests to be more realistic

* Prebid 2.32.0 Release

* increment pre version

* Rubicon doc: changing video test zone (#4187)

* added schain support to sonobi adapter (#4173)

* if schain config is not defined then error should not be thrown (#4165)

* if schain config is not defiend then error should not be thrown

* relaxed mode nodes param not defined error handled

* added test cases for config validation

* a curly bracket was missing in the example

* Rubicon: updating test params (#4190)

* myTargetBidAdapter: support currency config (#4188)

* Update README.md (#4193)

* Update README.md

* Update README.md

* cedato bid adapter instream video support (#4153)

* Added adxpremium prebid analytics adapter (#4181)

* feat(OAFLO-186): added support for schain (#4194)

* Sonobi - send entire userid payload (#4196)

* added userid param to pass the entire userId payload to sonobis bid request endpoint

* removed console log
git p

* fixed lint

* OpenX Adapter fix: updating outdated video examples (#4198)

* userId - Add support for refreshing the cached user id (#4082)

* [userId] Added support for refreshing the cached user id: refreshInSeconds storage parameter, related tests and implementation in id5 module

* [userId] Added support for refreshing the cached user id: refreshInSeconds storage parameter, related tests and implementation in id5 module

* UserId - ID5 - Updated doc with new contact point for partners

* UserId - Merged getStoredValue and getStoredDate

* [UserId] - ID5 - Moved back ID5 in ./modules

* UserId - ID5 - Fixed incorrect GDPR condition

* [UserId] - Doc update and test cleanup

* Prebid 2.33.0 Release

* Increment pre version

* SupplyChainObject support and fires a pixel onTimeout (#4152)

* - Implemented the 'onTimeout' callback to fire a pixel when there's a timeout.
- Added the ability to serialize an schain object according to the description provided here: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md

* some mods to the schain tag generation

* - added tests for schain param checking.

* - fixed a malformed url for timeouts

* - Removed a trailing ',' while generating a schain param.

* - Using the schain object from validBidRequest if present. Reverting to checking if params has it if not.

* - reverting changes to merge with master

* - Resolving merge issues

* Feature/add profile parameter (#4185)

* Add optional profile parameter

* EMXDigital Bid Adapter: Add video dimensions in request (#4174)

* addressed feedback from #3731 ticket

* removed commented code from emx test spec

* logging removed from spec

* flip h & w values from playerSize for video requests

* adding Outstream mediaType to EMX Digital

* adding device info. update to grab video param. styling changes.

* add video dimensions from playerSize

* fix test for video dimensions

* Added keywords parameter support in TrustX Bid Adapter (#4183)

* Add trustx adapter and tests for it

* update integration example

* Update trustx adapter

* Post-review fixes of Trustx adapter

* Code improvement for trustx adapter: changed default price type from gross to net

* Update TrustX adapter to support the 1.0 version

* Make requested changes for TrustX adapter

* Updated markdown file for TrustX adapter

* Fix TrustX adapter and spec file

* Update TrustX adapter: r parameter was added to ad request as cache buster

* Add support of gdpr to Trustx Bid Adapter

* Add wtimeout to ad request params for TrustX Bid Adapter

* TrustX Bid Adapter: remove last ampersand in the ad request

* Update TrustX Bid Adapter to support identical uids in parameters

* Update TrustX Bid Adapter to ignore bids that sizes do not match the size of the request

* Update TrustX Bid Adapter to support instream and outstream video

* Added wrapperType and wrapperVersion parameters in ad request for TrustX Bid Adapter

* Update TrustX Bid Adapter to use refererInfo instead depricated function utils.getTopWindowUrl

* HOTFIX for referrer encodind in TrustX Bid Adapter

* Fix test for TrustX Bid Adapter

* TrustX Bid Adapter: added keywords passing support

* rubicon: avoid passing unknown position (#4207)

* rubicon: not passing pos if not specified

* added comment

* not sending pos for video when undefined

* cleaning up test

* fixed unit test

* correctly reference bidrequest and determine mediatype of bidresponse (#4204)

* GumGum: only send gdprConsent when found (#4205)

* adds digitrust module, mods gdpr from bool to int

* update unit test

* only send gdprconsent if present

* LKQD: Use refererInfo.referer as fallback pageurl (#4210)

* Refactored URL query parameter passthrough for additional values, changed SSP endpoint to v.lkqd.net, and updated associated unit tests

* Use refererInfo.referer as fallback pageurl

* Removed logs and testing values

* [UserId] - ID5 - Fixed case when consentData is undefined (No CMP) (#4215)

* create stubs for localStorage in widespaceBidAdapter test file (#4208)

* added adId property to adRenderFailed event (#4097)

When no bid (therefore no adUnitCode) is available in the adRenderFailed event it can be difficult to identify the erroring slot.But in almost all cases the given slot still has the adId targeting.

* OpenX Adapter: Forcing https requests and adding UserID module support for LiveRamp and TTD (#4182)

* OpenX Adapter: Updated requests to force https

* OpenX Adapter: Added support for TTD's UnifiedID and LiveRamp's IDL

* PubMatic to support userId sub-modules (#4191)

* added support for pubcommon, digitrust, id5id

* added support for IdentityLink

* changed the source for id5

* added unit test cases

* changed source param for identityLink

* TripleLift support for UnifiedId and IdentityLink (#4197)

* Add IdentityLink support and fix UnifiedId.

It appears we've been looking for UnifiedId userIds
on the bidderRequest object, when they are found on bidRequests.
This commit fixes that error, and adds support for IdentityLink.

* change maintainer email to group

* Added lemma adapter (#4126)

* lemmaBidAdapter.js

Added lemma bid adapter file

* lemmaBidAdapter.md

Added lemma bid adapter md file

* lemmaBidAdapter_spec.js

Added lemma bid adapter test spec file

* Update lemmaBidAdapter.js

Fixed automated code review alert comparison between inconvertible types

* Update lemmaBidAdapter.js

Fixed review changes

* Update lemmaBidAdapter.md

Correct parameter value.

* Adkernel adapter new alias (#4221)

* Force https scheme for Criteo Bidder (#4227)

* assign adapter version number

* Ensure that Criteo's bidder is always called through https

* Add Video Support for Datablocks Bid Adapter (#4195)

* add datablocks Analytics and Bidder Adapters

* remove preload param

* remove preloadid

* better coverage of tests

* better coverage

* IE doesn't support array.find

* lint test

* update example host

* native asset id should be integer

* add datablocks Video

* remove isInteger

* skip if empty

* update adUnit, bidRequest and bidResponse object (#4180)

* update adUnit, bidRequest and bidResponse object

* add test for mediaTypes object

* 3 display banner and video vast support for rads (#4209)

* add stv adapter

* remove comments from adapter file

* start rads adapter

* fix adapter and tests

* fixes

* fix adapter and doc

* fix adapter

* fix tests

* little fix

* add ip param

* fix dev url

* #3 radsBidAdapter.md

* #3 radsBidAdapter.md: cleanup

* fix code and doc

* UserId - Add SameSite and server-side pubcid support (#3869)

* Add SameSite and server-side pubcid support

* Fix emoteevBidAdapter unit test

* added schain to appnexus bid adapter (#4229)

* added schain to appnexus bid adapter

* semicolon

* update doubleclick url (#4179)

* Prebid 2.34.0 release

* increment pre version

* Rubi Analytics handles > 1 bidResponse per bidRequest (#4224)

* videoNow bid adapter (#4088)

* -- first commit

* -- cors and bidder's name fixed

* -- almost ready

* -- added docs

* -- added nurl tracking

* -- bid params

* -- tests added

* -- test fixed

* -- replace placeholder in the onBidWon pixel's url

* -- commit for restart tests

* -- change response data format for display ad

* -- tests updated

* -- 100% tests coverage

* -- a few clean the test's code

* -- custom urls from localStorage

* -- tests updated

* -- a few clean the test's code

* -- new init model

* -- spec for new init model

* -- fix for new init model

* -- code cleaned

* -- 100% tests coverage

* -- 100% tests coverage

* -- fixed test

* -- commit for restart tests

* djax new bidder adapter  (#4192)

* djax bidder adapter

* djax bidder adapter

* Update hello_world.html

* Added Turk Telekom Bid Adapter (#4203)

* Added Turk Telekom Bid Adapter

* Fix md file for Turk Telekom Bid Adapter

* MicroAd: Use HTTPS in all requests (#4220)

* Always use HTTPS endpoint in MicroAd

* Update code

* Fixed a broken test in MicroAd

* Schain: avoiding Object.values as it is breaking on IE11 (#4238)

* added support for pubcommon, digitrust, id5id

* added support for IdentityLink

* changed the source for id5

* added unit test cases

* changed source param for identityLink

* avoiding use of Object.values

* 3952 delay auction for ids (#4115)

* 3952 delay auction for user ids

* 3952 add integration example

* 3952 add tests

* 3952 fix html example

* add todos

* 3952 continue auction if ids received

* 3952 add tests for auction delay

* increase test coverage

* set config for test

* remove todo

* add a few more checks to tests

* add comment, force tests to rerun

* Feature: adUnitBidLimit  (#3906)

* added new feature to config to limit bids when sendallbids is enabled

* cleaned up code. removed extra spaces etc

* removed trailing spaces in config

* remove .flat() and replaced with spread operator

* removed flat function and instead pushing using spread operator

* updated to use sendBidsControl instead

* updated targeting_spec to test bidLimit

* removed trailing spaces from targeting_spec

* Update Rubicon Adapter netRevenue default (#4242)

* Add microadBidAdapter

* Remove unnecessary encodeURIComponent from microadBidAdapter

* Submit Advangelists Prebid Adapter

* Submit Advangelists Prebid Adapter 1.1

* Correct procudtion endpoint for prebid

* analytics update with wrapper name

* reverted error merge

* update changed default value of netRevenue to true

* Removed AdastaMadia from alias (#4255)

* Update appnexusBidAdapter.js (#4251)

* IdentityLink - change expiration time to 30 days (#4239)

* Add coppa support for AppNexus adapter (#4253)

* Add coppa support for AppNexus adapter

* test name

* add new longform e2e tests (#4206)

* Konduit module (#4184)

* Adding Konduit module

* Removed superfluous arguments passed to obtainVastUrl function

* Removed superfluous arguments passed to obtainVastUrl function.

* Build trigger (empty commit)

* Module documentation updated according to the comments

* Logic in obtainVastUrl function updated according to the review comment.

* Removed hook, enabled eslint

* Circle CI runs e2e tests on every push (#4200)

* run functional tests on circle ci on push to any remote branch

* remove extraneous key from config file

* add test.localhost as alias to 127.0.0.1

* check 0: execute circle-ci

* move /etc/config to a separate command

* change bid partner to rubicon

* test appnexus bid adapter in ci

* comment browserstack command

* remove console.log statement

* test1: circle-ci

* change reference dev -> prod while loading prebid

* add console.log statement

* check-2: circle-ci

* comment browserstack testing

* change bid adapter

* change bid adapter

* remove test case for checking targeting keys

* remove the ci flag

* uncomment test for checking correct generation of targeting keys

* swap AN -> Rubicon for testing targeting keys

* Outcon bid adapter. (#4161)

* Outcon bid adapter.

* Fix identation

* Fixes

* Fixes

* Fixes

* Spec fixes

* Fixes

* Fix urls

* Fix

* Fix parameters

* Fix space operators

* Fix bidder timeout

* Update

* Fix whitespace

* no message

* Outcon unit test

* no message

* no message

* no message

* no message

* Fixes

* Fixes

* Change url

* no message

* no message

* no message

* Added bidId

* no message

* no message

* no message

* no message

* Wrapping url with html

* no message

* no message

* no message

* Adding workflow to run end to end tests (#4230)

* Adding workflow to run end to end tests

* trying self branch

* Update to run at 12 every day

* cleanup config using aliases

* update branch and cron time

* add command

* update prebid path for e2e test pages (#4274)

* Prebid 2.35.0 release

* Increment pre version

* Add usersync to adpone adapter (#4245)

* add user sync to adpone adapter

* move adpone usersync to global variable

* added withcredentials to http request

* fix http request options

* fix http request options

* add withCredentials: true

* add withCredentials: true

* added test coverage to usersync

* update sync function

* add test coverage

* adpone adapter

* package lock

* add more testing

* add more testing

* testing for onBidWon fucntion

* test onbidwon function

* trigger build

* Revert GumGum Adapter 2.28 resizing changes (#4277)

* changed resizing unit tests to return the first size dimensions in the sizes array

* added some changes

* reverted adapter changes

* SpotX Bid Adapter: Support schain, ID5 object, Google consent object, and hide_skin (#4281)

* Add SpotXBidAdapter

* Minor updates

* Undo testing changes to shared files

* Fix relative imports

* Remove superfluous imports and write a few more tests

* Formatting, ID5 object, Google consent objects

  - Added ID5 object support
  - Added Google Consent object
  - Reformatted indentaiton on spec file

* Revert content_width and content_height changes in docs

  - not sure how these got moved, lets put them back

* Remove click_to_replay flag in example

  - no reason to use this one in the example

* Spotx adapter - Add schain support and update unit tests

* Update schain path in ORTB 2.3 request body

	- schain object is now added to ortb request body
	  at request.ext.source.ext.schain

* Add hide_skin to documentation

  - whoops, this got removed, let's add it back

* Update Rubicon Analytics Adapter `bidId` to match PBS (#4156)

* Add microadBidAdapter

* Remove unnecessary encodeURIComponent from microadBidAdapter

* Submit Advangelists Prebid Adapter

* Submit Advangelists Prebid Adapter 1.1

* Correct procudtion endpoint for prebid

* analytics update with wrapper name

* reverted error merge

* update for rubicon analytics to send seat[].bid.id for PBS video and banner

* fixed conditional for server and video or banner

* updated with optimized value test for bidid

* update changed default value of netRevenue to true

* remove var declaration for rightSlot to correct lgtm error for unused variable

* update defineSlot div id to match div id defined in html body

* update test ad unit test props

* revert lock to match remote master

* add seatBidId to bidObj in rpBidAdapter interpretResponse

* update setTargeting to execute in the bids back handler

* remove dev integration test page

* meaningless commit to get lgtm to re-run

* SmartRTB adapter update (#4246)

* modules: Implement SmartRTB adapter and spec.

* Fix for-loop syntax to support IE; refactor getDomain out of exported set.

* Remove debugs, update doc

* Update test for video support

* Handle missing syncs. Add video to media types in sample ad unit

* Add null response check, update primary endpoint

* Note smrtb video requires renderer

* Support Vast Track (#4276)

* Add microadBidAdapter

* Remove unnecessary encodeURIComponent from microadBidAdapter

* Submit Advangelists Prebid Adapter

* Submit Advangelists Prebid Adapter 1.1

* Correct procudtion endpoint for prebid

* analytics update with wrapper name

* reverted error merge

* update changed default value of netRevenue to true

* Add parameters if config.cache.vasttrack is true

* Use requestId instead of adId

* Test new vasttrack payload params

* Removed commented out code

* Relaxed conditional check per review

* Removed commented out line

* Added 1000x250 size (#4295)

* prepare vidazoo adapter for v3.0 (#4291)

* Improve Digital adapter: support schain (#4286)

* LiveIntent Identity Module. (#4178)

* LiveIntentIdSystem. Initial implementation.

* LiveIntentIdSystem. Removed whitespace.

* Fixed typo

* Renamed variables, cookiesm added md.

* Changed the default identity url.

* Composite id, with having more than just the lipbid passed around.

* Composite id.

* Merge conflict resolution.

* Changed docs and param description.

* Added typedoc & mentioned liveIntentIdSystem in submodule.json.

* Extracted the LiveIntentIdSystem under modules, removed it from default userId modules.

* Fixing the 204 + no body scenario.

* Added liveIntent to submodule.json

* Fixing docs indentation.

* Updated prebidServer & specs.

* Minor specs update.

* updating liveintent eids source (#4300)

* updating liveintent eids source

these are supposed to be domains

* updating unit test

* fix appnexusBidAdapter view-script regex (#4289)

* fix an view script regex

* minor syntax update

* 33Across adding bidder specific extension field (#4298)

* - add 33across specific ext field for statedAt

* - fix unit test for 33Across adapter

* PubMatic to support LiveIntent User Id sub-module (#4306)

* added support for pubcommon, digitrust, id5id

* added support for IdentityLink

* changed the source for id5

* added unit test cases

* changed source param for identityLink

* supporting LiveIntent Id in PubMatic adapter

* updated source for liveintent

* Finteza Analytics Adapter: fix cookies (#4292)

* fix reading and sending cookies

* fix lint errors

* clear comments

* add unit tests

* fix calling of setCookies for IE

* clear cookies after test

* use own setCookie method inside tests

* Update LockerDome adapter to support Prebid 3.0 (#4301)

* Returning the `IdResponse` type with an obj + callback. Fix for 4304 (#4305)

*  Returning the `IdResponse` type with an obj + callback.

* Renamed resp -> result.

* Removed whitespace.

* ShowHeroes adapter - expanded outstream support (#4222)

* add ShowHeroes Adapter

* ShowHeroes adapter - expanded outstream support

* Revert "ShowHeroes adapter - expanded outstream support"

This reverts commit bfcdb913b52012b5afbf95a84956b906518a4b51.

* ShowHeroes adapter - expanded outstream support

* ShowHeroes adapter - fixes (#4222)

* ShowHeroes adapter - banner and outstream fixes (#4222)

* ShowHeroes adapter - description and outstream changes (#4222)

* ShowHeroes adapter - increase test coverage and small fix

* [Orbidder-Adapter] Add bidRequestCount and remove bid.params.keyValues (#4264)

* initial orbidder version in personal github repo

* use adUnits from orbidder_example.html

* replace obsolete functions

* forgot to commit the test

* check if bidderRequest object is available

* try to fix weird safari/ie issue

* ebayK: add more params

* update orbidderBidAdapter.md

* use spec.<function> instead of this.<function> for consistency reasons

* add bidfloor parameter to params object

* fix gdpr object handling

* …

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
