### PR TITLE
Added support for video params from mediaTypes obj

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1091,7 +1091,7 @@ export const spec = {
       bid = deepClone(originalBid);
       bid.params.adSlot = bid.params.adSlot || '';
       _parseAdSlot(bid);
-      if (bid.params.hasOwnProperty('video')) {
+      if ((bid.mediaTypes && bid.mediaTypes.hasOwnProperty('video')) || bid.params.hasOwnProperty('video')) {
         // Nothing to do
       } else {
         // If we have a native mediaType configured alongside banner, its ok if the banner size is not set in width and height

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -4172,5 +4172,45 @@ describe('PubMatic adapter', function () {
       spec.transformBidParams(bidRequests[0].params, true, videoAdUnit);
       expect(bidRequests[0].params.dctr).to.equal('key1:val1,val2|key2:val1');
     });
-  })
+  });
+
+  describe('Video request params', function() {
+    let sandbox, utilsMock, newVideoRequest;
+    beforeEach(() => {
+      utilsMock = sinon.mock(utils);
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(utils, 'logWarn');
+      newVideoRequest = utils.deepClone(videoBidRequests)
+    });
+
+    afterEach(() => {
+      utilsMock.restore();
+      sandbox.restore();
+    })
+
+    it('Should log warning if video params from mediaTypes and params obj of bid are not present', function () {
+      delete newVideoRequest[0].mediaTypes.video;
+      delete newVideoRequest[0].params.video;
+
+      let request = spec.buildRequests(newVideoRequest, {
+        auctionId: 'new-auction-id'
+      });
+
+      sinon.assert.calledOnce(utils.logWarn);
+      expect(request).to.equal(undefined);
+    });
+
+    it('Should consider video params from mediaType object of bid', function () {
+      delete newVideoRequest[0].params.video;
+
+      let request = spec.buildRequests(newVideoRequest, {
+        auctionId: 'new-auction-id'
+      });
+      let data = JSON.parse(request.data);
+      expect(data.imp[0].video).to.exist;
+      expect(data.imp[0]['video']['w']).to.equal(videoBidRequests[0].mediaTypes.video.playerSize[0]);
+      expect(data.imp[0]['video']['h']).to.equal(videoBidRequests[0].mediaTypes.video.playerSize[1]);
+      expect(data.imp[0]['video']['battr']).to.equal(undefined);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
