### PR TITLE
changes to backport lexicon to 6.18 with namespace changes

### DIFF
--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -77,6 +77,7 @@
                   "301": true,    // zeotapIdPlus
                   "91": true,     // criteo
                   "737": true,    // amxId
+                  "58": true,     // 33acrossId
                 }
               }
             }
@@ -126,6 +127,17 @@
                 "type": "html5",
                 "name": "unifiedid",
                 "expires": 30
+              }
+            },
+            {
+              "name": "33acrossId",
+              "params": {
+                "pid": '0'
+              },
+              "storage": {
+                "type": 'html5',
+                "name": '33acrossId',
+                "expires": 90
               }
             },
             {

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -1,5 +1,6 @@
 {
   "userId": [
+    "33acrossIdSystem",
     "admixerIdSystem",
     "adtelligentIdSystem",
     "akamaiDAPIdSystem",

--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -1,0 +1,115 @@
+/**
+ * This module adds 33acrossId to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/33acrossIdSystem
+ * @requires module:modules/userId
+ */
+
+import { logMessage, logError } from '../src/utils.js';
+import { ajaxBuilder } from '../src/ajax.js';
+import { submodule } from '../src/hook.js';
+import { uspDataHandler } from '../src/adapterManager.js';
+
+const MODULE_NAME = '33acrossId';
+const API_URL = 'https://lexicon.33across.com/v1/envelope';
+const AJAX_TIMEOUT = 10000;
+
+function getEnvelope(response) {
+  if (!response.succeeded) {
+    logError(`${MODULE_NAME}: Unsuccessful response`);
+
+    return;
+  }
+
+  if (!response.data.envelope) {
+    logMessage(`${MODULE_NAME}: No envelope was received`);
+
+    return;
+  }
+
+  return response.data.envelope;
+}
+
+function calculateQueryStringParams(pid, gdprConsentData) {
+  const uspString = uspDataHandler.getConsentData();
+  const gdprApplies = Boolean(gdprConsentData?.gdprApplies);
+  const params = {
+    pid,
+    gdpr: Number(gdprApplies),
+  };
+
+  if (uspString) {
+    params.us_privacy = uspString;
+  }
+
+  if (gdprApplies) {
+    params.gdpr_consent = gdprConsentData.consentString || '';
+  }
+
+  return params;
+}
+
+/** @type {Submodule} */
+export const thirthyThreeAcrossIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: MODULE_NAME,
+
+  gvlid: 58,
+
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} id
+   * @returns {{'33acrossId':{ envelope: string}}}
+   */
+  decode(id) {
+    return {
+      [MODULE_NAME]: {
+        envelope: id
+      }
+    };
+  },
+
+  /**
+   * performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @param {SubmoduleConfig} [config]
+   * @returns {IdResponse|undefined}
+   */
+  getId({ params = { } }, gdprConsentData) {
+    if (typeof params.pid !== 'string') {
+      logError(`${MODULE_NAME}: Submodule requires a partner ID to be defined`);
+
+      return;
+    }
+
+    const { pid, apiUrl = API_URL } = params;
+
+    return {
+      callback(cb) {
+        ajaxBuilder(AJAX_TIMEOUT)(apiUrl, {
+          success(response) {
+            let envelope;
+
+            try {
+              envelope = getEnvelope(JSON.parse(response))
+            } catch (err) {
+              logError(`${MODULE_NAME}: ID reading error:`, err);
+            }
+            cb(envelope);
+          },
+          error(err) {
+            logError(`${MODULE_NAME}: ID error response`, err);
+
+            cb();
+          }
+        }, calculateQueryStringParams(pid, gdprConsentData), { method: 'GET', withCredentials: true });
+      }
+    };
+  }
+};
+
+submodule('userId', thirthyThreeAcrossIdSubmodule);

--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -1,0 +1,53 @@
+# 33ACROSS ID
+
+For help adding this submodule, please contact [PrebidUIM@33across.com](PrebidUIM@33across.com).
+
+### Prebid Configuration
+
+You can configure this submodule in your `userSync.userIds[]` configuration:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [
+      {
+        name: "33acrossId",
+        storage: {
+          name: "33acrossId",
+          type: "html5",
+          expires: 90,
+          refreshInSeconds: 8*3600
+        },
+        params: {
+          pid: "0010b00002GYU4eBAH",
+        },
+      },
+    ],
+  },
+});
+```
+
+| Parameters under `userSync.userIds[]` | Scope    | Type   | Description                 | Example                                   |
+| ---| --- | --- | --- | --- |
+| name | Required | String | Name for the 33Across ID submodule | `"33acrossId"` |                                 |
+| storage                          | Required | Object | Configures how to cache User IDs locally in the browser | See [storage settings](#storage-settings) |
+| params                           | Required | Object | Parameters for 33Across ID submodule | See [params](#params)                     |
+
+### Storage Settings
+
+The following settings are available for the `storage` property in the `userSync.userIds[]` object:
+
+| Param name | Scope | Type | Description | Example   |
+| --- | --- | --- | --- | --- |
+| name | Required | String| Name of the cookie or HTML5 local storage where the user ID will be stored | `"33acrossId"` |
+| type | Required | String | `"html5"` (preferred)  or `"cookie"` | `"html5"` |
+| expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored. 33Across recommends `90`. | `90` |
+| refreshInSeconds | Strongly Recommended | Number | The interval (in seconds) for refreshing the user ID. 33Across recommends no more than 8 hours between refreshes. | `8*3600` |
+
+### Params
+
+The following settings are available in the `params` property in `userSync.userIds[]` object:
+
+| Param name | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| pid | Required | String | Partner ID provided by 33Across | `"0010b00002GYU4eBAH"` |

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -216,7 +216,14 @@ export const USER_IDS_CONFIG = {
     source: 'verizonmedia.com',
     atype: 3
   },
-
+  // 33across ID
+  '33acrossId': {
+    source: '33across.com',
+    atype: 1,
+    getValue: function(data) {
+      return data.envelope;
+    }
+  },
   // Neustar Fabrick
   'fabrickId': {
     source: 'neustar.biz',

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -2,6 +2,13 @@
 
 ```
 userIdAsEids = [
+     {
+        source: '33across.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1
+        }]
+    },
     {
         source: 'trustpid.com',
         uids: [{

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -6,6 +6,18 @@ Example showing `cookie` storage for user id data for each of the submodules
 pbjs.setConfig({
     userSync: {
         userIds: [{
+            name: "33acrossId",
+            storage: {
+                type: "cookie",
+                name: "33acrossId",
+                expires: 90,
+                refreshInSeconds: 8*3600
+            },
+            params: {
+                pid: "0010b00002GYU4eBAH" // Example ID
+            }
+        },
+        {
             name: "pubCommonId",
             storage: {
                 type: "cookie",

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -1,0 +1,413 @@
+import { thirthyThreeAcrossIdSubmodule } from 'modules/33acrossIdSystem.js';
+import * as utils from 'src/utils.js';
+
+import { server } from 'test/mocks/xhr.js';
+import { uspDataHandler } from 'src/adapterManager.js';
+
+describe('33acrossIdSystem', () => {
+  describe('name', () => {
+    it('should expose the name of the submodule', () => {
+      expect(thirthyThreeAcrossIdSubmodule.name).to.equal('33acrossId');
+    });
+  });
+
+  describe('gvlid', () => {
+    it('should expose the vendor id', () => {
+      expect(thirthyThreeAcrossIdSubmodule.gvlid).to.equal(58);
+    });
+  });
+
+  describe('getId', () => {
+    it('should call endpoint and handle valid response', () => {
+      const completeCallback = sinon.spy();
+
+      const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+        params: {
+          pid: '12345'
+        }
+      });
+
+      callback(completeCallback);
+
+      const [request] = server.requests;
+
+      request.respond(200, {
+        'Content-Type': 'application/json'
+      }, JSON.stringify({
+        succeeded: true,
+        data: {
+          envelope: 'foo'
+        },
+        expires: 1645667805067
+      }));
+
+      expect(request.method).to.equal('GET');
+      expect(request.withCredentials).to.be.true;
+      expect(request.url).to.contain('https://lexicon.33across.com/v1/envelope?pid=12345');
+      expect(completeCallback.calledOnceWithExactly('foo')).to.be.true;
+    });
+
+    context('when GDPR applies', () => {
+      it('should call endpoint with \'gdpr=1\'', () => {
+        const completeCallback = () => {};
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        }, {
+          gdprApplies: true
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        expect(request.url).to.contain('gdpr=1');
+      });
+
+      context('and the consent string is given', () => {
+        it('should call endpoint with the GDPR consent string', () => {
+          [
+            { consentString: '', expected: '' },
+            { consentString: undefined, expected: '' },
+            { consentString: 'foo', expected: 'foo' }
+          ].forEach(({ consentString, expected }, index) => {
+            const completeCallback = () => {};
+            const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+              params: {
+                pid: '12345'
+              }
+            }, {
+              gdprApplies: true,
+              consentString
+            });
+
+            callback(completeCallback);
+
+            expect(server.requests[index].url).to.contain(`gdpr_consent=${expected}`);
+          });
+        });
+      });
+    });
+
+    context('when GDPR doesn\'t apply', () => {
+      it('should call endpoint with \'gdpr=0\' and no GDPR consent string parameter', () => {
+        const completeCallback = () => {};
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        }, {
+          gdprApplies: false,
+          consentString: 'foo'
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        expect(request.url).to.contain('gdpr=0');
+        expect(request.url).not.to.contain('gdpr_consent');
+      });
+    });
+
+    context('when a valid US Privacy string is given', () => {
+      it('should call endpoint with the US Privacy parameter', () => {
+        const completeCallback = () => {};
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        sinon.stub(uspDataHandler, 'getConsentData').returns('1YYY');
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        expect(request.url).to.contain('us_privacy=1YYY');
+
+        uspDataHandler.getConsentData.restore();
+      });
+    });
+
+    context('when an invalid US Privacy is given', () => {
+      it('should call endpoint without the US Privacy parameter', () => {
+        const completeCallback = () => {};
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        // null or any other falsy value is considered invalid.
+        sinon.stub(uspDataHandler, 'getConsentData').returns(null);
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        expect(request.url).not.to.contain('us_privacy');
+
+        uspDataHandler.getConsentData.restore();
+      });
+    });
+
+    context('when the partner ID is not given', () => {
+      it('should log an error', () => {
+        const logErrorSpy = sinon.spy(utils, 'logError');
+
+        thirthyThreeAcrossIdSubmodule.getId({
+          params: { /* No 'pid' param */ }
+        });
+
+        expect(logErrorSpy.calledOnceWithExactly('33acrossId: Submodule requires a partner ID to be defined')).to.be.true;
+
+        logErrorSpy.restore();
+      });
+    });
+
+    context('when the partner ID has an incorrect format', () => {
+      it('should log an error', () => {
+        const logErrorSpy = sinon.spy(utils, 'logError');
+
+        thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: 123456 // PID must be a string
+          }
+        });
+
+        expect(logErrorSpy.calledOnceWithExactly('33acrossId: Submodule requires a partner ID to be defined')).to.be.true;
+
+        logErrorSpy.restore();
+      });
+    });
+
+    context('when the server JSON is invalid', () => {
+      it('should log an error', () => {
+        const logErrorSpy = sinon.spy(utils, 'logError');
+        const completeCallback = () => {};
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, 'invalid response');
+
+        expect(logErrorSpy.lastCall.args[0]).to.eq(`${thirthyThreeAcrossIdSubmodule.name}: ID reading error:`);
+
+        logErrorSpy.restore();
+      });
+
+      it('should execute complete callback with undefined value', () => {
+        const completeCallback = sinon.spy();
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, 'invalid response');
+
+        expect(completeCallback.calledOnceWithExactly(undefined)).to.be.true;
+      });
+    });
+
+    context('when an endpoint override is given', () => {
+      it('should call that endpoint', () => {
+        const completeCallback = sinon.spy();
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345',
+            apiUrl: 'https://staging-lexicon.33across.com/v1/envelope'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: true,
+          data: {
+            envelope: 'foo'
+          },
+          expires: 1645667805067
+        }));
+
+        expect(request.url).to.contain('https://staging-lexicon.33across.com/v1/envelope?pid=12345');
+      });
+    });
+
+    context('when the server returns an unsuccessful response', () => {
+      it('should log an error', () => {
+        const logErrorSpy = sinon.spy(utils, 'logError');
+        const completeCallback = () => {};
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: false,
+          error: 'foo'
+        }));
+
+        expect(logErrorSpy.calledOnceWithExactly(`${thirthyThreeAcrossIdSubmodule.name}: Unsuccessful response`)).to.be.true;
+
+        logErrorSpy.restore();
+      });
+
+      it('should execute complete callback with undefined value', () => {
+        const completeCallback = sinon.spy();
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: false,
+          error: 'foo'
+        }));
+
+        expect(completeCallback.calledOnceWithExactly(undefined)).to.be.true;
+      });
+    });
+
+    context('when the server returns a successful response but without ID', () => {
+      it('should log a message', () => {
+        const logMessageSpy = sinon.spy(utils, 'logMessage');
+        const completeCallback = () => {};
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: true,
+          data: {}
+        }));
+
+        expect(logMessageSpy.calledOnceWithExactly(`${thirthyThreeAcrossIdSubmodule.name}: No envelope was received`)).to.be.true;
+
+        logMessageSpy.restore();
+      });
+
+      it('should execute complete callback with undefined value', () => {
+        const completeCallback = sinon.spy();
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: true,
+          data: {}
+        }));
+
+        expect(completeCallback.calledOnceWithExactly(undefined)).to.be.true;
+      });
+    });
+
+    context('when the server returns an error status code', () => {
+      it('should log an error', () => {
+        const logErrorSpy = sinon.spy(utils, 'logError');
+        const completeCallback = () => {};
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(404);
+
+        expect(logErrorSpy.calledOnceWithExactly(`${thirthyThreeAcrossIdSubmodule.name}: ID error response`, 'Not Found')).to.be.true;
+
+        logErrorSpy.restore();
+      });
+
+      it('should execute complete callback without any value', () => {
+        const completeCallback = sinon.spy();
+
+        const { callback } = thirthyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(404);
+
+        expect(completeCallback.calledOnceWithExactly()).to.be.true;
+      });
+    })
+  })
+
+  describe('decode', () => {
+    it('should wrap the given value inside an object literal', () => {
+      expect(thirthyThreeAcrossIdSubmodule.decode('foo')).to.deep.equal({
+        [thirthyThreeAcrossIdSubmodule.name]: {
+          envelope: 'foo'
+        }
+      });
+    });
+  });
+});

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -363,6 +363,23 @@ describe('eids array generation for known sub-modules', function() {
       }]
     });
   });
+
+  it('33acrossId', function() {
+    const userId = {
+      '33acrossId': {
+        envelope: 'some-random-id-value'
+      }
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: '33across.com',
+      uids: [{
+        id: 'some-random-id-value',
+        atype: 1
+      }]
+    });
+  });
 });
 describe('Negative case', function() {
   it('eids array generation for UN-known sub-module', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
