### PR TITLE
Openwrap JS should set req.test in the auction request whenever pubma…

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -564,17 +564,19 @@ function findPartnersWithoutErrorsAndBids(erroredPartners, listofPartnersWithmi,
 }
 /**
  * Checks if window.location.search(i.e. string of query params on the page URL) 
- * has specified query param with a value.
+ * has specified query param with a values.
  * ex. pubmaticTest=1
  * @param {*} paramName Query param name ex. pubmaticTest
- * @param {*} value Value for the same ex. 1
+ * @param {*} values Values for the same ex. [1, true]
  * @returns boolean
  */
-function hasQueryParam(paramName, value) {
+function hasQueryParam(paramName, values) {
   const queryParams = window?.location?.search;
-  if(!queryParams || !paramName || !value) return false;
-  const searchStr = `${paramName}=${value}`;
-  return (queryParams.indexOf(searchStr)) > -1 ? true : false;
+  if(!queryParams || !paramName || !values || !values?.length) return false;
+  return values.some(value => {
+    const searchStr = `${paramName.toLowerCase()}=${value}`;
+    return (queryParams.toLowerCase().indexOf(searchStr)) > -1 ? true : false;   
+  });
 }
 
 function ORTB2(s2sBidRequest, bidderRequests, adUnits, requestedBidders) {
@@ -914,7 +916,7 @@ Object.assign(ORTB2.prototype, {
 
     //  Check if location URL has a query param pubmaticTest=1 then set test=1
     //  else we don't need to send test: 0 to request payload.
-    if(hasQueryParam("pubmaticTest", 1)) request.test = 1;
+    if(hasQueryParam("pubmaticTest", [1, true])) request.test = 1;
 
     // If the price floors module is active, then we need to signal to PBS! If floorData obj is present is best way to check
     if (typeof deepAccess(firstBidRequest, 'bids.0.floorData') === 'object') {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -562,6 +562,20 @@ function findPartnersWithoutErrorsAndBids(erroredPartners, listofPartnersWithmi,
     }
   })
 }
+/**
+ * Checks if window.location.search(i.e. string of query params on the page URL) 
+ * has specified query param with a value.
+ * ex. pubmaticTest=1
+ * @param {*} paramName Query param name ex. pubmaticTest
+ * @param {*} value Value for the same ex. 1
+ * @returns boolean
+ */
+function hasQueryParam(paramName, value) {
+  const queryParams = window?.location?.search;
+  if(!queryParams || !paramName || !value) return false;
+  const searchStr = `${paramName}=${value}`;
+  return (queryParams.indexOf(searchStr)) > -1 ? true : false;
+}
 
 function ORTB2(s2sBidRequest, bidderRequests, adUnits, requestedBidders) {
   this.s2sBidRequest = s2sBidRequest;
@@ -897,6 +911,10 @@ Object.assign(ORTB2.prototype, {
         }
       }
     };
+
+    //  Check if location URL has a query param pubmaticTest=1 then set test=1
+    //  else we don't need to send test: 0 to request payload.
+    if(hasQueryParam("pubmaticTest", 1)) request.test = 1;
 
     // If the price floors module is active, then we need to signal to PBS! If floorData obj is present is best way to check
     if (typeof deepAccess(firstBidRequest, 'bids.0.floorData') === 'object') {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -570,7 +570,7 @@ function findPartnersWithoutErrorsAndBids(erroredPartners, listofPartnersWithmi,
  * @param {*} values Values for the same ex. [1, true]
  * @returns boolean
  */
-function hasQueryParamByRegex(paramName, values) {
+function hasQueryParam(paramName, values) {
   if(!paramName || !values || !values?.length) return false;
   let paramValue = getParameterByName(paramName);
   if(!paramValue) return false;
@@ -914,7 +914,7 @@ Object.assign(ORTB2.prototype, {
 
     //  TEST BID: Check if location URL has a query param pubmaticTest=true then set test=1
     //  else we don't need to send test: 0 to request payload.
-    if(hasQueryParamByRegex('pubmaticTest', [true])) request.test = 1;
+    if(hasQueryParam('pubmaticTest', [true])) request.test = 1;
 
     // If the price floors module is active, then we need to signal to PBS! If floorData obj is present is best way to check
     if (typeof deepAccess(firstBidRequest, 'bids.0.floorData') === 'object') {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -566,17 +566,16 @@ function findPartnersWithoutErrorsAndBids(erroredPartners, listofPartnersWithmi,
  * Checks if window.location.search(i.e. string of query params on the page URL) 
  * has specified query param with a values.
  * ex. pubmaticTest=1
- * @param {*} paramName Query param name ex. pubmaticTest
+ * @param {*} regexp regexp for which param lokking for ex. /pubmatictest=(.*?)(&|$)/g
  * @param {*} values Values for the same ex. [1, true]
  * @returns boolean
  */
-function hasQueryParam(paramName, values) {
-  const queryParams = window?.location?.search;
-  if(!queryParams || !paramName || !values || !values?.length) return false;
-  return values.some(value => {
-    const searchStr = `${paramName.toLowerCase()}=${value}`;
-    return (queryParams.toLowerCase().indexOf(searchStr)) > -1 ? true : false;   
-  });
+function hasQueryParamByRegex(regexp, values) {
+  const queryParams = window?.location?.search?.toLowerCase();
+  if(!queryParams || !regexp || !values || !values?.length) return false;
+  var matches = regexp.exec(queryParams);
+  if (matches?.length >= 2) return values?.some(value => value?.toString()?.toLowerCase() == matches?.[1]);
+  return false;
 }
 
 function ORTB2(s2sBidRequest, bidderRequests, adUnits, requestedBidders) {
@@ -916,7 +915,7 @@ Object.assign(ORTB2.prototype, {
 
     //  Check if location URL has a query param pubmaticTest=1 then set test=1
     //  else we don't need to send test: 0 to request payload.
-    if(hasQueryParam("pubmaticTest", [1, true])) request.test = 1;
+    if(hasQueryParamByRegex(/pubmatictest=(.*?)(&|$)/g, [1, true])) request.test = 1;
 
     // If the price floors module is active, then we need to signal to PBS! If floorData obj is present is best way to check
     if (typeof deepAccess(firstBidRequest, 'bids.0.floorData') === 'object') {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -4,7 +4,7 @@ import {
   getPrebidInternal, logError, isStr, isPlainObject, logWarn, generateUUID, bind, logMessage,
   triggerPixel, insertUserSyncIframe, deepAccess, mergeDeep, deepSetValue, cleanObj, parseSizesInput,
   getBidRequest, getDefinedParams, createTrackPixelHtml, pick, deepClone, uniques, flatten, isNumber,
-  isEmpty, isArray, logInfo, timestamp
+  isEmpty, isArray, logInfo, timestamp, getParameterByName
 } from '../../src/utils.js';
 import CONSTANTS from '../../src/constants.json';
 import adapterManager from '../../src/adapterManager.js';
@@ -565,17 +565,16 @@ function findPartnersWithoutErrorsAndBids(erroredPartners, listofPartnersWithmi,
 /**
  * Checks if window.location.search(i.e. string of query params on the page URL) 
  * has specified query param with a values.
- * ex. pubmaticTest=1
- * @param {*} regexp regexp for which param lokking for ex. /pubmatictest=(.*?)(&|$)/g
+ * ex. pubmaticTest=true
+ * @param {*} paramName regexp for which param lokking for ex. pubmaticTest
  * @param {*} values Values for the same ex. [1, true]
  * @returns boolean
  */
-function hasQueryParamByRegex(regexp, values) {
-  const queryParams = window?.location?.search?.toLowerCase();
-  if(!queryParams || !regexp || !values || !values?.length) return false;
-  var matches = regexp.exec(queryParams);
-  if (matches?.length >= 2) return values?.some(value => value?.toString()?.toLowerCase() == matches?.[1]);
-  return false;
+function hasQueryParamByRegex(paramName, values) {
+  if(!paramName || !values || !values?.length) return false;
+  let paramValue = getParameterByName(paramName);
+  if(!paramValue) return false;
+  return values?.some(value => value?.toString()?.toLowerCase() == paramValue?.toString()?.toLowerCase());
 }
 
 function ORTB2(s2sBidRequest, bidderRequests, adUnits, requestedBidders) {
@@ -913,9 +912,9 @@ Object.assign(ORTB2.prototype, {
       }
     };
 
-    //  Check if location URL has a query param pubmaticTest=1 then set test=1
+    //  TEST BID: Check if location URL has a query param pubmaticTest=true then set test=1
     //  else we don't need to send test: 0 to request payload.
-    if(hasQueryParamByRegex(/pubmatictest=(.*?)(&|$)/g, [1, true])) request.test = 1;
+    if(hasQueryParamByRegex('pubmaticTest', [true])) request.test = 1;
 
     // If the price floors module is active, then we need to signal to PBS! If floorData obj is present is best way to check
     if (typeof deepAccess(firstBidRequest, 'bids.0.floorData') === 'object') {


### PR DESCRIPTION
…ticTest=1 is sent in the page URL.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Open wrap JS should set req.test in the auction request whenever pubmaticTest=1 is sent in the page URL.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
