### PR TITLE
Uoe 8059 480

### DIFF
--- a/modules/viewabilityScoreGeneration.js
+++ b/modules/viewabilityScoreGeneration.js
@@ -129,29 +129,29 @@ export const calculateBucket = (bucketCategories, score) => {
 
 export const addViewabilityTargeting = (globalConfig, targetingSet, vsgLocalStorageObj, cb) => {
   Object.keys(targetingSet).forEach(targetKey => {
-    // Will add only required targetting keys by this module. 
-    targetingSet[targetKey] = {};
-    if (
-      vsgLocalStorageObj[targetKey] &&
-      Object.keys(targetingSet[targetKey]).length !== 0 &&
-      vsgLocalStorageObj[targetKey].hasOwnProperty('viewed') &&
-      vsgLocalStorageObj[targetKey].hasOwnProperty('rendered')
-    ) {
-      const viewabilityScore = Math.round((vsgLocalStorageObj[targetKey].viewed / vsgLocalStorageObj[targetKey].rendered) * 10) / 10;
-      const viewabilityBucket = calculateBucket(globalConfig[MODULE_NAME][TARGETING].bucketCategories, viewabilityScore);
+    if(Object.keys(targetingSet[targetKey]).length !== 0) {
+      // Will add only required targetting keys by this module. 
+      targetingSet[targetKey] = {};
+      if (
+        vsgLocalStorageObj[targetKey] &&
+        vsgLocalStorageObj[targetKey].hasOwnProperty('viewed') &&
+        vsgLocalStorageObj[targetKey].hasOwnProperty('rendered')
+      ) {
+        const viewabilityScore = Math.round((vsgLocalStorageObj[targetKey].viewed / vsgLocalStorageObj[targetKey].rendered) * 10) / 10;
+        const viewabilityBucket = calculateBucket(globalConfig[MODULE_NAME][TARGETING].bucketCategories, viewabilityScore);
 
-      if (globalConfig[MODULE_NAME][TARGETING].score) {
-        const targetingScoreKey = globalConfig[MODULE_NAME][TARGETING].scoreKey ? globalConfig[MODULE_NAME][TARGETING].scoreKey : 'bidViewabilityScore';
-        targetingSet[targetKey][targetingScoreKey] = viewabilityScore;
-      }
+        if (globalConfig[MODULE_NAME][TARGETING].score) {
+          const targetingScoreKey = globalConfig[MODULE_NAME][TARGETING].scoreKey ? globalConfig[MODULE_NAME][TARGETING].scoreKey : 'bidViewabilityScore';
+          targetingSet[targetKey][targetingScoreKey] = viewabilityScore;
+        }
 
-      if (globalConfig[MODULE_NAME][TARGETING].bucket) {
-        const targetingBucketKey = globalConfig[MODULE_NAME][TARGETING].bucketKey ? globalConfig[MODULE_NAME][TARGETING].bucketKey : 'bidViewabilityBucket';
-        targetingSet[targetKey][targetingBucketKey] = viewabilityBucket;
+        if (globalConfig[MODULE_NAME][TARGETING].bucket) {
+          const targetingBucketKey = globalConfig[MODULE_NAME][TARGETING].bucketKey ? globalConfig[MODULE_NAME][TARGETING].bucketKey : 'bidViewabilityBucket';
+          targetingSet[targetKey][targetingBucketKey] = viewabilityBucket;
+        }
       }
     }
   });
-
   cb(targetingSet);
 };
 

--- a/modules/viewabilityScoreGeneration.js
+++ b/modules/viewabilityScoreGeneration.js
@@ -129,14 +129,14 @@ export const calculateBucket = (bucketCategories, score) => {
 
 export const addViewabilityTargeting = (globalConfig, targetingSet, vsgLocalStorageObj, cb) => {
   Object.keys(targetingSet).forEach(targetKey => {
+    // Will add only required targetting keys by this module. 
+    targetingSet[targetKey] = {};
     if (
       vsgLocalStorageObj[targetKey] &&
       Object.keys(targetingSet[targetKey]).length !== 0 &&
       vsgLocalStorageObj[targetKey].hasOwnProperty('viewed') &&
       vsgLocalStorageObj[targetKey].hasOwnProperty('rendered')
     ) {
-      // Will add only required targetting keys by this module. 
-      targetingSet[targetKey] = {};
       const viewabilityScore = Math.round((vsgLocalStorageObj[targetKey].viewed / vsgLocalStorageObj[targetKey].rendered) * 10) / 10;
       const viewabilityBucket = calculateBucket(globalConfig[MODULE_NAME][TARGETING].bucketCategories, viewabilityScore);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Wrong targeting keys are sent in DFP when VSC code snippet is added for adv gpt scenario

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
