### PR TITLE
Vsg updates

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1219,7 +1219,7 @@ export const spec = {
     }
 
     if (bid.bidViewability) {
-	  vsgObj =  getAndParseFromLocalStorage('viewability-data');
+      vsgObj = getAndParseFromLocalStorage('viewability-data');
       removeUnwantedKeys(vsgObj[vsgDomain]);
       payload.ext.bidViewability = {
         adDomain: vsgObj[vsgDomain]

--- a/modules/viewabilityScoreGeneration.js
+++ b/modules/viewabilityScoreGeneration.js
@@ -14,8 +14,26 @@ const GPT_SLOT_VISIBILITY_CHANGED_EVENT = 'slotVisibilityChanged';
 const TOTAL_VIEW_TIME_LIMIT = 1000000000;
 const domain = window.location.hostname;
 
+const fireStatHatLogger = (statKeyName) => {
+  var stathatUserEmail = 'jason.quaccia@pubmatic.com';
+  var url = 'https://api.stathat.com/ez';
+  var data = `time=${(new Date()).getTime()}&stat=${statKeyName}&email=${stathatUserEmail}&count=1`
+
+  var statHatElement = document.createElement('script');
+  statHatElement.src = url + '?' + data;
+  statHatElement.async = true;
+  document.body.appendChild(statHatElement)
+};
+
 export const getAndParseFromLocalStorage = key => JSON.parse(window.localStorage.getItem(key));
-export const setAndStringifyToLocalStorage = (key, object) => { window.localStorage.setItem(key, JSON.stringify(object)); };
+export const setAndStringifyToLocalStorage = (key, object) => {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(object));
+  } catch (e) {
+    // send error to stathat endpoint
+    fireStatHatLogger(`${e} --- ${window.location.href}`);
+  }
+};
 
 let vsgObj = getAndParseFromLocalStorage('viewability-data');
 
@@ -89,14 +107,16 @@ const incrementRenderCount = keyArr => {
       } else {
         vsgObj[key] = {
           rendered: 1,
-          viewed: 0
+          viewed: 0,
+          createdAt: Date.now()
         }
       }
     } else {
       vsgObj = {
         [key]: {
           rendered: 1,
-          viewed: 0
+          viewed: 0,
+          createdAt: Date.now()
         }
       }
     }
@@ -228,6 +248,7 @@ export const updateGptWithViewabilityTargeting = targetingSet => {
 export const setGptEventHandlers = () => {
   events.on(CONSTANTS.EVENTS.AUCTION_INIT, () => {
     // add the GPT event listeners
+    // the event handlers below get triggered in the following order: slotRenderEnded, slotVisibilityChanged and impressionViewable
     window.googletag = window.googletag || {};
     window.googletag.cmd = window.googletag.cmd || [];
     window.googletag.cmd.push(() => {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- added ability to preserve the totalViewtime, render and view averages if/when the totalViewtime values goes over a predefined max amount (total view time limit = 1,000,000,000 and the number to divide it by if totalViewTime >= to that limit is 2)
- local storage now also collects viewability data on the domain and ad slot size level 
- updated how viewability data is passed to translator, now it is in the following format:
```
{
...
  "ext": {
    "bidViewability": {
      adDomain: {
        "rendered": ..,
        "viewed": ..,
        "totalViewTime: .., (if applicable)
        "createdAt": ..
      }
    }
  },  
  "imp": [
        {
            "ext": {
                "bidViewability": {
                    adUnit: { // only the relative ad unit viewability data based on the ad slot element id passed here for a specific impression
                      "rendered": ..,
                      "viewed": ..,
                      "totalViewTime: .., (if applicable)
                      "createdAt": ..
                    },
                    adSizes: { // only pass ad size level viewability data relative to the size or sizes included in the specific ad unit above
                      adSize1: {
                        "rendered": ..,
                        "viewed": ..,
                        "totalViewTime: .., (if applicable)
                        "createdAt": ..
                      },
                      adSizeN: {
                        "rendered": ..,
                        "viewed": ..,
                        "totalViewTime: .., (if applicable)
                        "createdAt": ..
                      }
                    }
                },
            },
        }
    ],
  ...
}
```
- no longer passing `lastViewed` or `updatedAt` keys to translator
- no longer storing the `updatedAt` key in local storage
- updated relative unit tests and wrote additional ones where appropriate
- added a call to stathat in scenarios where there is an error when attempting to set bidviewability data to local storage
