### PR TITLE
UOE-9585: Add `it`(IntegrationType) field in logger

### DIFF
--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -430,7 +430,8 @@ function getTgId() {
 }
 
 function getIntegrationType() {
-  const s2sBiddersLength = config.getConfig('s2sConfig')['bidders'].length;
+  let s2sConfig = config.getConfig('s2sConfig');
+  const s2sBiddersLength = s2sConfig && s2sConfig.bidders && isArray(s2sConfig.bidders) ? s2sConfig.bidders.length : 0;
   const integrationType = s2sBiddersLength !== 0 ? 'hybrid' : 'web';
   return integrationType;
 }
@@ -481,7 +482,6 @@ function executeBidsLoggerCall(e, highestCpmBids) {
   outputObj['bm'] = window.PWT && window.PWT.browserMapping;
   outputObj['ih'] = identityOnly;
   outputObj['it'] = getIntegrationType()
-
   outputObj['tpv'] = frequencyDepth?.pageView;
   outputObj['trc'] = frequencyDepth?.slotCnt;
   outputObj['tbs'] = frequencyDepth?.bidServed;

--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -431,9 +431,7 @@ function getTgId() {
 
 function getIntegrationType() {
   let s2sConfig = config.getConfig('s2sConfig');
-  const s2sBiddersLength = s2sConfig && s2sConfig.bidders && isArray(s2sConfig.bidders) ? s2sConfig.bidders.length : 0;
-  const integrationType = s2sBiddersLength !== 0 ? 'hybrid' : 'web';
-  return integrationType;
+  return s2sConfig?.bidders?.length ? 'hybrid' : 'web';
 }
 
 function getFloorFetchStatus(floorData) {

--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -429,6 +429,12 @@ function getTgId() {
   return 0;
 }
 
+function getIntegrationType() {
+  const s2sBiddersLength = config.getConfig('s2sConfig')['bidders'].length;
+  const integrationType = s2sBiddersLength !== 0 ? 'hybrid' : 'web';
+  return integrationType;
+}
+
 function getFloorFetchStatus(floorData) {
   if (!floorData?.floorRequestData) {
     return false;
@@ -474,6 +480,8 @@ function executeBidsLoggerCall(e, highestCpmBids) {
   outputObj['dvc'] = {'plt': getDevicePlatform()};
   outputObj['bm'] = window.PWT && window.PWT.browserMapping;
   outputObj['ih'] = identityOnly;
+  outputObj['it'] = getIntegrationType()
+
   outputObj['tpv'] = frequencyDepth?.pageView;
   outputObj['trc'] = frequencyDepth?.slotCnt;
   outputObj['tbs'] = frequencyDepth?.bidServed;

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -404,6 +404,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.tst).to.equal(1519767016);
 	    expect(data.bm).not.to.be.null;
       expect(data.tgid).to.equal(15);
+      expect(data.it).to.equal('hybrid');
       expect(data.fmv).to.equal('floorModelTest');
       expect(data.ft).to.equal(1);
       expect(data.s).to.be.an('array');
@@ -632,6 +633,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s.length).to.equal(2);
 	    expect(data.bm).not.to.be.null;
       expect(data.tgid).to.equal(0);
+      expect(data.it).to.equal('hybrid');
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
@@ -708,6 +710,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.pid).to.equal('1111');
 	  expect(data.bm).not.to.be.null;
       expect(data.tgid).to.equal(0);// test group id should be between 0-15 else set to 0
+      expect(data.it).to.equal('hybrid');
       expect(data.fmv).to.equal('floorModelTest');
       expect(data.ft).to.equal(1);
       expect(data.s).to.be.an('array');
@@ -762,6 +765,7 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
 	  expect(data.bm).not.to.be.null;
       expect(data.tgid).to.equal(0);// test group id should be an INT between 0-15 else set to 0
+      expect(data.it).to.equal('hybrid');
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].au).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].mt).to.be.an('array');
@@ -1226,6 +1230,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.tst).to.equal(1519767016);
 	    expect(data.bm).not.to.be.null;
       expect(data.tgid).to.equal(15);
+      expect(data.it).to.equal('hybrid');
       expect(data.fmv).to.equal('floorModelTest');
       expect(data.ft).to.equal(1);
       expect(data.s).to.be.an('array');
@@ -1359,6 +1364,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.tst).to.equal(1519767016);
 	    expect(data.bm).not.to.be.null;
       expect(data.tgid).to.equal(15);
+      expect(data.it).to.equal('hybrid');
       expect(data.fmv).to.equal('floorModelTest');
       expect(data.ft).to.equal(1);
       expect(data.s).to.be.an('array');
@@ -1486,6 +1492,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.orig).to.equal('www.test.com');
       expect(data.tst).to.equal(1519767016);
       expect(data.tgid).to.equal(15);
+      expect(data.it).to.equal('hybrid');
       expect(data.tpv).to.be.not.null;
       expect(data.tbs).to.be.not.null;
       expect(data.trc).to.be.not.null;
@@ -1564,6 +1571,40 @@ describe('pubmatic analytics adapter', function () {
       expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.ih).to.equal(0);
+    });
+
+    it('Logger: check value of it field incase of empty bidders in s2sConfig', function() {
+      this.timeout(5000)
+
+      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
+        return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
+      });
+
+      config.setConfig({
+        testGroupId: 15,
+        s2sConfig: {
+          timeout: 1000,
+          accountId: 10000,
+          bidders: []
+        }
+      });
+
+      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[1]);
+      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
+      events.emit(BID_WON, MOCK.BID_WON[0]);
+      events.emit(BID_WON, MOCK.BID_WON[1]);
+
+      clock.tick(2000 + 1000);
+      expect(requests.length).to.equal(3); // 1 logger and 2 win-tracker
+      let request = requests[2]; // logger is executed late, trackers execute first
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      let data = getLoggerJsonFromRequest(request.requestBody);
+      expect(data.it).to.equal('web');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
