### PR TITLE
Replaced mili seconds value with seconds for UNIX_TIMESTAMP macro

### DIFF
--- a/libraries/pbsExtensions/processors/custom.js
+++ b/libraries/pbsExtensions/processors/custom.js
@@ -112,7 +112,7 @@ export function setReqParams(ortbRequest, bidderRequest, context, {am = adapterM
     if (!isEmpty(videoParams)) {
       // adding [UNIX_TIMESTAMP] & [WRAPPER_IMPRESSION_ID] in macros as it is required for tracking events.
       if (ortbRequest?.ext?.prebid && ortbRequest?.ext?.prebid.macros) {
-        ortbRequest.ext.prebid.macros['[UNIX_TIMESTAMP]'] = timestamp().toString();
+        ortbRequest.ext.prebid.macros['[UNIX_TIMESTAMP]'] = Math.round(timestamp() / 1000).toString();
         ortbRequest.ext.prebid.macros['[WRAPPER_IMPRESSION_ID]'] = iidValue.toString();
       }
     }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1055,6 +1055,31 @@ describe('S2S Adapter', function () {
         expect(requestBid.imp[0].video.context).to.be.undefined;
       });
 
+	  it('should set UNIX_TIMESTAMP for video request', function () {
+        let videoBid = utils.deepClone(VIDEO_REQUEST);
+        videoBid.ad_units[0].mediaTypes.video.context = 'instream';
+        adapter.callBids(videoBid, BID_REQUESTS, addBidResponse, done, ajax);
+
+        const requestBid = JSON.parse(server.requests[0].requestBody);
+        expect(requestBid.imp[0].video).to.exist;
+        expect(requestBid.imp[0].video.placement).to.equal(1);
+        expect(requestBid.ext.prebid.macros).to.exist;
+        expect(requestBid.ext.prebid.macros).to.have.property('UNIX_TIMESTAMP');
+      });
+
+	  it('should set UNIX_TIMESTAMP in seconds and a string for video request', function () {
+        let videoBid = utils.deepClone(VIDEO_REQUEST);
+        videoBid.ad_units[0].mediaTypes.video.context = 'instream';
+        adapter.callBids(videoBid, BID_REQUESTS, addBidResponse, done, ajax);
+        const requestBid = JSON.parse(server.requests[0].requestBody);
+        expect(requestBid.imp[0].video).to.exist;
+        expect(requestBid.imp[0].video.placement).to.equal(1);
+        expect(requestBid.ext.prebid.macros).to.exist;
+        expect(requestBid.ext.prebid.macros.UNIX_TIMESTAMP).to.be.a('string');
+        expect(requestBid.ext.prebid.macros).to.have.property('UNIX_TIMESTAMP');
+        expect(requestBid.ext.prebid.macros).to.have.lengthOf(10);
+      });
+
       it('converts video mediaType properties into openRTB format', function () {
         let ortb2Config = utils.deepClone(CONFIG);
         ortb2Config.endpoint.p1Consent = 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
