### PR TITLE
bidderCode specific fix for safari users

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -31,9 +31,9 @@
     "device": null,
     "os": "Windows"
   },
-  "bs_safari_latest_mac_bigsur": {
+  "bs_safari_latest_mac": {
     "base": "BrowserStack",
-    "os_version": "Big Sur",
+    "os_version": "Sonoma",
     "browser": "safari",
     "browser_version": "latest",
     "device": null,

--- a/libraries/ortbConverter/converter.js
+++ b/libraries/ortbConverter/converter.js
@@ -178,7 +178,7 @@ export function ortbConverter({
         throw new Error('ortbRequest passed to `fromORTB` must be the same object returned by `toORTB`')
       }
       function augmentContext(ctx, extraParams = {}) {
-        return Object.assign(ctx, {ortbRequest: request}, extraParams, ctx);
+        return Object.assign(ctx, {ortbRequest: request}, extraParams);
       }
       const impsById = Object.fromEntries((request.imp || []).map(imp => [imp.id, imp]));
       let impForSlots, partnerBidsForslots;

--- a/test/spec/ortbConverter/converter_spec.js
+++ b/test/spec/ortbConverter/converter_spec.js
@@ -80,6 +80,7 @@ describe('pbjs-ortb converter', () => {
             if (context.reqContext?.ctx) {
               bidResponse.reqCtx = context.reqContext?.ctx;
             }
+			bidResponse.seatbid = context.seatbid;
           }
         }
       },
@@ -116,13 +117,16 @@ describe('pbjs-ortb converter', () => {
     const response = cvt.fromORTB({request, response: MOCK_ORTB_RESPONSE});
     expect(response.bids).to.eql([{
       impid: 'imp0',
-      bidId: 111
+      bidId: 111,
+      seatbid: MOCK_ORTB_RESPONSE.seatbid[0]
     }, {
       impid: 'imp1',
-      bidId: 112
+      bidId: 112,
+      seatbid: MOCK_ORTB_RESPONSE.seatbid[0]
     }, {
       impid: 'imp1',
-      bidId: 112
+      bidId: 112,
+      seatbid: MOCK_ORTB_RESPONSE.seatbid[1]
     }]);
     expect(response.marker).to.be.true;
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
