### PR TITLE
phase 1.5: remove metrics fields from the tracker call

### DIFF
--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -534,38 +534,45 @@ function getCDSDataLoggerStr() {
 }
 
 // Logging this information to take informed decision on what consent config to be applied.
-export function getConsentInfo() {
+export function getConsentInfo(skipMetricsField) {
   const { cmConfig } = window.PWT || {};
   if (!cmConfig || typeof cmConfig != 'object') return {};
 
-  // When PWT.getDurationOf function available
-  const metrics = isFn(window.PWT?.getDurationOf) ? {
-    trnslt: window.PWT.getDurationOf('TRANSLATOR_CALLING_TIME'),
-    lrt: window.PWT.getDurationOf('LOGGER_CALLING_TIME'),
-    trt: window.PWT.getDurationOf('TRACKER_CALLING_TIME')
-  } : {};
-
-  // When the traffic is from 95% (allStatsAvailable: false) of the traffic we do not have all the stats available
-  if (!cmConfig?.allStatsAvailable) return metrics;
-
-  // Return everything from cmConfig object
-  return {
+  const dimensions = {
     ccmp: cmConfig?.cmpPresent,
     ccmps: cmConfig?.complianceSupport,
     ccmpid: cmConfig?.cmpId,
-    cgst: metricsAvailable('GEO_CALLING_TIME'),
-    ccmpt: metricsAvailable('CMP_CALLING_TIME'),
-    csc: cmConfig?.geoInfo?.sc,
-    ...metrics
+    csc: cmConfig?.geoInfo?.sc
+  };
+
+  if (skipMetricsField) {
+    return cmConfig.allStatsAvailable ? dimensions : {};
   }
 
-  function metricsAvailable(metricName) {
-    return isFn(window.PWT?.getDurationOf) ? window.PWT.getDurationOf(metricName) : null;
+  const getDurationOf = window.PWT?.getDurationOf;
+  const isGetDurationOfFn = isFn(getDurationOf);
+
+  // When PWT.getDurationOf function available
+  const metrics = isGetDurationOfFn ? {
+    trnslt: getDurationOf('TRANSLATOR_CALLING_TIME'),
+    lrt: getDurationOf('LOGGER_CALLING_TIME'),
+    trt: getDurationOf('TRACKER_CALLING_TIME')
+  } : {};
+
+  if (cmConfig?.allStatsAvailable) {
+    return {
+      ...dimensions,
+      ...metrics,
+      cgst: isGetDurationOfFn ? getDurationOf('GEO_CALLING_TIME') : null,
+      ccmpt: isGetDurationOfFn ? getDurationOf('CMP_CALLING_TIME') : null,
+    };
   }
+
+  return metrics;
 }
 
 export function getConsentInfoStr() {
-  let cmInfo = getConsentInfo();
+  let cmInfo = getConsentInfo(true);
   return Object.keys(cmInfo).reduce((queryString, key) => {
     const value = cmInfo[key];
     const encodedValue = (value != null && value != undefined) ? enc(value) : null;
@@ -664,7 +671,7 @@ function executeBidsLoggerCall(e, highestCpmBids) {
   }
   outputObj = {
     ...outputObj,
-    ...getConsentInfo()
+    ...getConsentInfo(false)
   };
 
   auctionCache.sent = true;

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -2102,10 +2102,10 @@ describe('pubmatic analytics adapter', function () {
 
     it('should return an empty object if cmConfig is not an object', function () {
       window.PWT.cmConfig = null;
-      expect(getConsentInfo()).to.deep.equal({});
+      expect(getConsentInfo(false)).to.deep.equal({});
 
       window.PWT.cmConfig = undefined;
-      expect(getConsentInfo()).to.deep.equal({});
+      expect(getConsentInfo(false)).to.deep.equal({});
     });
 
     it('should return metrics if getDurationOf is a function and allStatsAvailable is false', function () {
@@ -2127,7 +2127,7 @@ describe('pubmatic analytics adapter', function () {
         trt: 300
       };
 
-      expect(getConsentInfo()).to.deep.equal(expectedMetrics);
+      expect(getConsentInfo(false)).to.deep.equal(expectedMetrics);
     });
 
     it('should return cmConfig properties and metrics when allStatsAvailable is true', function () {
@@ -2163,7 +2163,7 @@ describe('pubmatic analytics adapter', function () {
         trt: 300
       };
 
-      expect(getConsentInfo()).to.deep.equal(expectedInfo);
+      expect(getConsentInfo(false)).to.deep.equal(expectedInfo);
     });
 
     it('should return metrics with null values if getDurationOf is not a function', function () {
@@ -2179,7 +2179,7 @@ describe('pubmatic analytics adapter', function () {
         csc: undefined
       };
 
-      expect(getConsentInfo()).to.deep.equal(expectedInfo);
+      expect(getConsentInfo(false)).to.deep.equal(expectedInfo);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
