### PR TITLE
Added "dm" and "dmv" keys to logger and tracker (#12854)

### DIFF
--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -72,6 +72,10 @@ export function composeIdObject(value) {
   if (value.bidswitch) {
     result.bidswitch = { 'id': value.bidswitch, ext: { provider: LI_PROVIDER_DOMAIN } }
   }
+  
+  if (value.triplelift) {
+    result.triplelift = { 'id': value.triplelift, ext: { provider: LI_PROVIDER_DOMAIN } }
+  }
 
   if (value.medianet) {
     result.medianet = { 'id': value.medianet, ext: { provider: LI_PROVIDER_DOMAIN } }
@@ -248,6 +252,18 @@ export const eids = {
   },
   'sonobi': {
     source: 'liveintent.sonobi.com',
+    atype: 3,
+    getValue: function(data) {
+      return data.id;
+    },
+    getUidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
+    }
+  },
+  'triplelift': {
+    source: 'liveintent.triplelift.com',
     atype: 3,
     getValue: function(data) {
       return data.id;

--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -22,6 +22,7 @@ const FLOOR_VALUES = {
 /// /////////// CONSTANTS //////////////
 const ADAPTER_CODE = 'pubmatic';
 const VENDOR_OPENWRAP = 'openwrap';
+const DISPLAY_MANAGER = 'Prebid.js';
 const SEND_TIMEOUT = 2000;
 const END_POINT_HOST = 'https://t.pubmatic.com/';
 const END_POINT_BID_LOGGER = END_POINT_HOST + 'wl?';
@@ -622,7 +623,8 @@ function executeBidsLoggerCall(e, highestCpmBids) {
   outputObj['tis'] = frequencyDepth?.impressionServed;
   outputObj['lip'] = frequencyDepth?.lip;
   outputObj['tgid'] = getTgId();
-  outputObj['pbv'] = '$prebid.version$' || '-1';
+  outputObj['dm'] = DISPLAY_MANAGER;
+  outputObj['dmv'] = '$prebid.version$' || '-1';
 
   if (floorData) {
     const floorRootValues = getFloorsCommonField(floorData?.floorRequestData);
@@ -733,6 +735,8 @@ function executeBidWonLoggerCall(auctionId, adUnitId, isIma) {
   pixelURL += '&kgpv=' + enc(getValueForKgpv(winningBid, adUnitId));
   pixelURL += '&rf=' + enc(origAdUnit?.pubmaticAutoRefresh?.isRefreshed ? 1 : 0);
   pixelURL += '&origbidid=' + enc(winningBid?.bidResponse?.partnerImpId || winningBidId);
+  pixelURL += '&dm=' + enc(DISPLAY_MANAGER);
+  pixelURL += '&dmv=' + enc('$prebid.version$' || '-1');
   pixelURL += '&di=' + enc(winningBid?.bidResponse?.dealId || OPEN_AUCTION_DEAL_ID);
   const ds = winningBid.bidResponse?.meta ? getMetadata(winningBid.bidResponse.meta)?.ds : undefined;
   if (ds) {

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -30,6 +30,8 @@ const {
   SET_TARGETING
 } = EVENTS;
 
+const DISPLAY_MANAGER = 'Prebid.js';
+
 const BID = {
   'bidder': 'pubmatic',
   'width': 640,
@@ -629,6 +631,8 @@ describe('pubmatic analytics adapter', function () {
 	    expect(data.fsrc).to.equal(2);
 	    expect(data.fp).to.equal('pubmatic');
       expect(data.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.dm).to.equal(DISPLAY_MANAGER);
+      expect(data.dmv).to.equal('$prebid.version$' || '-1');
       expect(data.s).to.be.an('array');
       expect(data.s.length).to.equal(2);
       expect(data.owv).to.equal(window?.PWT?.versionDetails?.openwrap_version || '-1');
@@ -740,6 +744,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.af).to.equal('video');
       expect(data.ds).to.equal('1208');
       expect(data.ffs).to.equal('1');
+      expect(data.dm).to.equal(DISPLAY_MANAGER);
+      expect(data.dmv).to.equal('$prebid.version$' || '-1');
     });
 
     it('Logger: do not log floor fields when prebids floor shows noData in location property', function() {
@@ -871,6 +877,8 @@ describe('pubmatic analytics adapter', function () {
 	    expect(data.fsrc).to.equal(2);
 	    expect(data.fp).to.equal('pubmatic');
       expect(data.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.dm).to.equal(DISPLAY_MANAGER);
+      expect(data.dmv).to.equal('$prebid.version$' || '-1');
       expect(data.s).to.be.an('array');
       expect(data.s.length).to.equal(2);
 	    expect(data.bm).not.to.be.null;
@@ -959,7 +967,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.it).to.equal('hybrid');
       expect(data.fmv).to.equal('floorModelTest');
       expect(data.ft).to.equal(1);
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.dm).to.equal(DISPLAY_MANAGER);
+      expect(data.dmv).to.equal('$prebid.version$' || '-1');
       expect(data.s).to.be.an('array');
       expect(data.s.length).to.equal(2);
       // slot 1
@@ -1555,7 +1564,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.tgid).to.equal(15);
       expect(data.it).to.equal('hybrid');
       expect(data.fmv).to.equal('floorModelTest');
-      expect(data.pbv).to.equal('$prebid.version$' || '-1');
+      expect(data.dm).to.equal(DISPLAY_MANAGER);
+      expect(data.dmv).to.equal('$prebid.version$' || '-1');
       expect(data.ft).to.equal(1);
 	  expect(data.ffs).to.equal(1);
 	  expect(data.fsrc).to.equal(2);
@@ -1699,6 +1709,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.ffs).to.equal(1);
 	    expect(data.fsrc).to.equal(2);
 	    expect(data.fp).to.equal('pubmatic');
+      expect(data.dm).to.equal(DISPLAY_MANAGER);
+      expect(data.dmv).to.equal('$prebid.version$' || '-1');
       expect(data.ft).to.equal(1);
       expect(data.s).to.be.an('array');
       expect(data.s.length).to.equal(2);


### PR DESCRIPTION
Added "dm" and "dmv" keys to logger and tracker (#12854)

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
