### PR TITLE
added json validation in gzip compression func

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1414,7 +1414,10 @@ export const spec = {
       method: 'POST',
       url: ENDPOINT + '?source=ow-client',
       data: JSON.stringify(payload),
-      bidderRequest: bidderRequest
+      bidderRequest: bidderRequest,
+      options: {
+        endpointCompression: true
+      }
     };
 
     // Allow translator request to execute it as GET Methoid if flag is set.

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -19,10 +19,6 @@ import {
   parseSizesInput,
   pick,
   uniques,
-  // eslint-disable-next-line no-unused-vars
-  isStr,
-  // eslint-disable-next-line no-unused-vars
-  isJsonObject,
   isGzipCompressionSupported,
   compressDataWithGZip,
   getParameterByName,

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -497,8 +497,23 @@ export const processBidderRequests = hook('sync', function (spec, bids, bidderRe
         );
         break;
       case 'POST':
-        const enableGZipCompression = bidderSettings.get(spec.code, 'endpointCompression');
+        const enableGZipCompression = request.options?.endpointCompression;
         const debugMode = getParameterByName(DEBUG_MODE).toUpperCase() === 'TRUE' || debugTurnedOn();
+        const callAjax = ({ url, payload }) => {
+          ajax(
+            url,
+            {
+              success: onSuccess,
+              error: onFailure
+            },
+            payload,
+            getOptions({
+              method: 'POST',
+              contentType: 'text/plain',
+              withCredentials: true
+            })
+          );
+        };
 
         if (enableGZipCompression && debugMode) {
           logWarn(`Skipping GZIP compression for ${spec.code} as debug mode is enabled`);
@@ -510,41 +525,10 @@ export const processBidderRequests = hook('sync', function (spec, bids, bidderRe
             if (!url.searchParams.has('gzip')) {
               url.searchParams.set('gzip', '1');
             }
-
-            ajax(
-              url.href,
-              {
-                success: onSuccess,
-                error: onFailure
-              },
-              compressedPayload,
-              getOptions({
-                method: 'POST',
-                contentType: 'text/plain',
-                // adding below header creates a CORS preflight request so we should not pass it
-                // instead of adding this header we can pass a query parmeter (gzip=1) to let server know that the payload is compressed
-                // TODO: update URL to include query parameter gzip=1
-                // customHeaders: {
-                //  'Content-Encoding': 'gzip',
-                // },
-                withCredentials: true
-              })
-            );
+            callAjax({ url: url.href, payload: compressedPayload });
           });
         } else {
-          ajax(
-            request.url,
-            {
-              success: onSuccess,
-              error: onFailure
-            },
-            typeof request.data === 'string' ? request.data : JSON.stringify(request.data),
-            getOptions({
-              method: 'POST',
-              contentType: 'text/plain',
-              withCredentials: true
-            })
-          );
+          callAjax({ url: request.url, payload: typeof request.data === 'string' ? request.data : JSON.stringify(request.data) });
         }
         break;
       default:

--- a/src/utils.js
+++ b/src/utils.js
@@ -1312,8 +1312,7 @@ export const isGzipCompressionSupported = (function () {
       if (typeof window.CompressionStream === 'undefined') {
         cachedResult = false;
       } else {
-        // eslint-disable-next-line no-unused-vars
-        let newCompressionStream = new window.CompressionStream('gzip'); // Will throw an error if unsupported
+        (() => new window.CompressionStream('gzip'))();
         cachedResult = true;
       }
     } catch (error) {
@@ -1326,11 +1325,18 @@ export const isGzipCompressionSupported = (function () {
 
 // Make sure to use isGzipCompressionSupported before calling this function
 export async function compressDataWithGZip(data) {
-  const encoder = new TextEncoder();
-  const encodedData = encoder.encode(data); // Convert to Uint8Array
-  // eslint-disable-next-line no-unused-vars
-  const originalSize = encodedData.length; // Get original data size in bytes
+  if (typeof data !== 'string') {
+    data = JSON.stringify(data);
+  }
 
+  try {
+    JSON.parse(data);
+  } catch (e) {
+    throw new Error('Data cannot be stringified to valid JSON.');
+  }
+
+  const encoder = new TextEncoder();
+  const encodedData = encoder.encode(data);
   const compressedStream = new Blob([encodedData])
     .stream()
     .pipeThrough(new window.CompressionStream('gzip'));

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1074,6 +1074,14 @@ describe('PubMatic adapter', function () {
         expect(request.method).to.equal('POST');
       });
 
+      it('should set endpointCompression to true in request options', () => {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+        expect(request).to.have.property('options');
+        expect(request.options).to.have.property('endpointCompression').to.equal(true);
+      });
+
       it('should return bidderRequest property', function() {
         let request = spec.buildRequests(bidRequests, validOutstreamBidRequest);
         expect(request.bidderRequest).to.equal(validOutstreamBidRequest);

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1771,17 +1771,14 @@ describe('bidderFactory', () => {
       getParameterByNameStub.withArgs(DEBUG_MODE).returns('false');
       debugTurnedOnStub.returns(false);
 
-      window.$$PREBID_GLOBAL$$.bidderSettings = {
-        [CODE]: {
-          endpointCompression: true
-        }
-      };
-
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: url,
-        data: data
+        data: data,
+        options: {
+          endpointCompression: true
+        }
       });
 
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
@@ -1804,17 +1801,14 @@ describe('bidderFactory', () => {
       getParameterByNameStub.withArgs(DEBUG_MODE).returns('false');
       debugTurnedOnStub.returns(false);
 
-      window.$$PREBID_GLOBAL$$.bidderSettings = {
-        [CODE]: {
-          endpointCompression: true
-        }
-      };
-
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({
         method: 'POST',
         url: url,
-        data: data
+        data: data,
+        options: {
+          endpointCompression: false
+        }
       });
 
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
@@ -1828,19 +1822,13 @@ describe('bidderFactory', () => {
       });
     });
 
-    it('should send uncompressed data if gzip is supported but disabled in settings', function (done) {
+    it('should send uncompressed data if gzip is supported but disabled in request options', function (done) {
       const bidder = newBidder(spec);
       const url = 'https://test.url.com';
       const data = { arg: 'value' };
       isGzipSupportedStub.returns(true);
       getParameterByNameStub.withArgs(DEBUG_MODE).returns('false');
       debugTurnedOnStub.returns(false);
-
-      window.$$PREBID_GLOBAL$$.bidderSettings = {
-        [CODE]: {
-          endpointCompression: false
-        }
-      };
 
       spec.isBidRequestValid.returns(true);
       spec.buildRequests.returns({

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1244,40 +1244,33 @@ describe('Utils', function () {
   });
 
   describe('isGzipCompressionSupported', () => {
-    let originalIsGzipCompressionSupported;
+    let sandbox;
 
     beforeEach(() => {
-      // Store original function reference
-      originalIsGzipCompressionSupported = utils.isGzipCompressionSupported;
-
-      // Reset cachedResult manually
-      utils.isGzipCompressionSupported = (function () {
-        let cachedResult; // Reset cached value
-
+      sandbox = sinon.createSandbox();
+      sandbox.stub(utils, 'isGzipCompressionSupported').callsFake((() => {
+        let cachedResult;
         return function () {
           if (cachedResult !== undefined) {
             return cachedResult;
           }
-
           try {
             if (typeof window.CompressionStream === 'undefined') {
               cachedResult = false;
             } else {
-              let newCompressionStream = new window.CompressionStream('gzip'); // Will throw an error if unsupported
+              let newCompressionStream = new window.CompressionStream('gzip');
               cachedResult = true;
             }
           } catch (error) {
             cachedResult = false;
           }
-
           return cachedResult;
         };
-      })();
+      })());
     });
 
     afterEach(() => {
-      // Restore original function after each test
-      utils.isGzipCompressionSupported = originalIsGzipCompressionSupported;
+      sandbox.restore();
     });
 
     it('should return true if CompressionStream is available', () => {
@@ -1330,12 +1323,23 @@ describe('Utils', function () {
     });
 
     it('should compress data correctly when CompressionStream is available', async () => {
-      const data = 'Test data';
+      const data = JSON.stringify({ test: 'data' });
       const compressedData = await utils.compressDataWithGZip(data);
 
       expect(compressedData).to.be.instanceOf(Uint8Array);
       expect(compressedData.length).to.be.greaterThan(0);
       expect(compressedData).to.deep.equal(new Uint8Array([1, 2, 3, 4]));
+    });
+
+    it('should throw an error if invalid JSON is passed', async () => {
+      const invalidData = 'Test data';
+
+      try {
+        await utils.compressDataWithGZip(invalidData);
+        throw new Error('Expected compressDataWithGZip to throw');
+      } catch (err) {
+        expect(err.message).to.equal('Data cannot be stringified to valid JSON.');
+      }
     });
   });
 });


### PR DESCRIPTION
made a few updates to the bid request gzip compression feature to stay in-sync with the latest on vanilla pbjs: https://github.com/prebid/Prebid.js/pull/13033

- added validation within the gzip compression function to check for valid json and to also make sure json is always stringified (if it is valid)
- fixed a few various tests