### PR TITLE
Adding dayOfweek feature in rtdModule

### DIFF
--- a/libraries/pubmaticUtils/plugins/floorProvider.js
+++ b/libraries/pubmaticUtils/plugins/floorProvider.js
@@ -1,7 +1,7 @@
 // plugins/floorProvider.js
 import { logInfo, logError, isFn, logMessage, isEmpty, mergeDeep } from '../../../src/utils.js';
 import { getOS } from '../../userAgentUtils/index.js';
-import { getBrowserType, getCurrentTimeOfDay, getUtmValue, getDeviceType as fetchDeviceType } from '../pubmaticUtils.js';
+import { getBrowserType, getCurrentTimeOfDay, getUtmValue, getDayOfWeek, getDeviceType as fetchDeviceType } from '../pubmaticUtils.js';
 import { config as conf } from '../../../src/config.js';
 
 /**
@@ -123,6 +123,7 @@ export const getDeviceType = () => fetchDeviceType();
 export const getCountry = () => getConfigJsonManager().country || (window.PWT?.CC?.cc ? window.PWT.CC.cc : '');
 export const getBidder = (request) => request?.bidder;
 export const getUtm = () => getUtmValue();
+export const getDOW = () => getDayOfWeek();
 
 export const prepareFloorsConfig = () => {
   // TODO: This can be removed as it is beimg used for UTR only and handled for multipliers in name: 'floor.json', for UPR it is handled in
@@ -186,6 +187,7 @@ export const prepareFloorsConfig = () => {
         os: getOs,
         utm: getUtm,
         country: getCountry,
+        dayOfWeek: getDOW,
         bidder: getBidder,
       },
     },

--- a/libraries/pubmaticUtils/pubmaticUtils.js
+++ b/libraries/pubmaticUtils/pubmaticUtils.js
@@ -85,6 +85,11 @@ export const getDeviceType = () => {
   return deviceType;
 } 
 
+export const getDayOfWeek = () => {
+  const dayOfWeek = new Date().getDay();
+  return dayOfWeek.toString();
+}
+
 /**
  * Determines whether an action should be throttled based on a given percentage.
  *

--- a/test/spec/libraries/pubmaticUtils/plugins/floorProvider_spec.js
+++ b/test/spec/libraries/pubmaticUtils/plugins/floorProvider_spec.js
@@ -174,6 +174,11 @@ describe('FloorProvider', () => {
       expect(floorProvider.getUtm()).to.equal('evening');
     });
 
+    it('getDOW should return result from getDayOfWeek', async () => {
+      const stub = sinon.stub(pubmaticUtils, 'getDayOfWeek').returns('2');
+      expect(floorProvider.getDOW()).to.equal('2');
+    });
+
     it('getBidder should return bidder from request', async () => {
       floorProvider.init('dynamicFloors', { getConfigByName: () => floorsobj });
       expect(floorProvider.getBidder({ bidder: 'pubmatic' })).to.equal('pubmatic');

--- a/test/spec/modules/pubmaticRtdProvider_spec.js
+++ b/test/spec/modules/pubmaticRtdProvider_spec.js
@@ -315,6 +315,7 @@ describe('Pubmatic RTD Provider', () => {
                 'os',
                 'country',
                 'utm',
+                'dayOfWeek',
                 'bidder'
             ]);
 
@@ -363,6 +364,7 @@ describe('Pubmatic RTD Provider', () => {
             expect(result.floors.additionalSchemaFields.os).to.equal(getOs);
             expect(result.floors.additionalSchemaFields.country).to.equal(getCountry);
             expect(result.floors.additionalSchemaFields.utm).to.equal(getUtm);
+            expect(result.floors.additionalSchemaFields.dayOfWeek).to.equal(getDayOfWeek);
             expect(result.floors.additionalSchemaFields.bidder).to.equal(getBidder);
         });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding dayOfweek feature in rtdModule


```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
